### PR TITLE
custom hint for checkbox

### DIFF
--- a/src/components/TeeForm.vue
+++ b/src/components/TeeForm.vue
@@ -80,14 +80,21 @@
           :model-value="formData[field.id]"
           :name="field.id" 
           :required="field.required"
-          :hint="field.hint[choices.lang]"
           @update:modelValue="updateFormData($event, field.id)">
+          <!-- :hint="field.hint[choices.lang]" -->
           <template #label>
             <span>
               {{ field.label[choices.lang] }}
             </span>
           </template>
         </DsfrCheckbox>
+        <!-- CHECKBOX HINT -->
+        <div v-if="field.type == 'checkbox'">
+          <span
+            class="fr-hint-text fr-mt-5v"
+            v-html="field.hint[choices.lang]">
+          </span>
+        </div>
       </div>
 
     </div>

--- a/src/questionnaire/trackResults.ts
+++ b/src/questionnaire/trackResults.ts
@@ -111,7 +111,7 @@ export const results = {
           à la transition écologique de votre entreprise.
           <br>
           Voir également nos 
-          <a href=http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies">
+          <a href="http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies">
             Conditions Générales d'Utilisation
           </a>.
           <br>

--- a/src/questionnaire/trackResults.ts
+++ b/src/questionnaire/trackResults.ts
@@ -108,9 +108,12 @@ export const results = {
           c'est-à-dire pour vous recontacter par email ou par téléphone 
           afin de vous aider à vous orienter et à vous conseiller 
           dans votre recherche d'aides
-          à la transition écologique de votre entreprise.<br>
+          à la transition écologique de votre entreprise.
+          <br>
           Voir également nos 
-          <a href=http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies">Conditions Générales d'Utilisation</a>.
+          <a href=http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies">
+            Conditions Générales d'Utilisation
+          </a>.
           <br>
           <br>
           Pour toute question vous pouvez nous contacter à "france-transition(at)beta.gouv.fr"

--- a/src/questionnaire/trackResults.ts
+++ b/src/questionnaire/trackResults.ts
@@ -100,7 +100,7 @@ export const results = {
       },
       {
         id: 'cgu',
-        help: 'https://aidantsconnect.beta.gouv.fr/cgu/',
+        help: 'http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies',
         label: { fr: "J'accepte d'être recontacté par l'équipe de Transition Ecologique des Entreprises *"},
         hint: { fr: `
           Vos données à caractère personnel seront uniquement utilisées à des fins légitimes et nécessaires

--- a/src/questionnaire/trackResults.ts
+++ b/src/questionnaire/trackResults.ts
@@ -109,9 +109,8 @@ export const results = {
           afin de vous aider à vous orienter et à vous conseiller 
           dans votre recherche d'aides
           à la transition écologique de votre entreprise.
-          <br>
           Voir également nos 
-          <a href="http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies">
+          <a href="http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies" target="_blank">
             Conditions Générales d'Utilisation
           </a>.
           <br>

--- a/src/questionnaire/trackResults.ts
+++ b/src/questionnaire/trackResults.ts
@@ -110,7 +110,7 @@ export const results = {
           dans votre recherche d'aides
           à la transition écologique de votre entreprise.<br>
           Voir également nos 
-          <a href="https://aidantsconnect.beta.gouv.fr/cgu/">Conditions Générales d'Utilisation</a>.
+          <a href=http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies">Conditions Générales d'Utilisation</a>.
           <br>
           <br>
           Pour toute question vous pouvez nous contacter à "france-transition(at)beta.gouv.fr"

--- a/src/questionnaire/trackResults.ts
+++ b/src/questionnaire/trackResults.ts
@@ -108,8 +108,11 @@ export const results = {
           c'est-à-dire pour vous recontacter par email ou par téléphone 
           afin de vous aider à vous orienter et à vous conseiller 
           dans votre recherche d'aides
-          à la transition écologique de votre entreprise.
-          Voir les Conditions Générales d'Utilisation (page en cours de rédaction).
+          à la transition écologique de votre entreprise.<br>
+          Voir également nos 
+          <a href="https://aidantsconnect.beta.gouv.fr/cgu/">Conditions Générales d'Utilisation</a>.
+          <br>
+          <br>
           Pour toute question vous pouvez nous contacter à "france-transition(at)beta.gouv.fr"
         ` },
         required: true,


### PR DESCRIPTION
Resolves #12 

Adds a link in the form's checkbox hint before the form's "send" button. 

Link to : http://mission-transition.beta.gouv.fr/donnee-personnelles-et-cookies

---

![Capture d’écran 2023-06-02 à 16 57 29](https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/727f1dfe-8137-4257-822e-3c9fd03b9172)
