### PR TITLE
refactor: rename ci job

### DIFF
--- a/.github/workflows/test-data.yml
+++ b/.github/workflows/test-data.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main, preprod ]
 
 jobs:
-  build:
+  validate-data:
+    name: Validation des données de dispositifs sur la base d'un JSON Schema
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Rename wrong "build" to "validate-data" with explicit name. 