### PR TITLE
fix: debug back to track keeping user's selection within track component

### DIFF
--- a/packages/web/src/components/TeeSidebar.vue
+++ b/packages/web/src/components/TeeSidebar.vue
@@ -130,7 +130,7 @@ const usedCategories = computed(() => {
 const backToTrack = async (trackId: string) => {
   // console.log()
   // console.log('TeeSidebar > backToTrack > trackId :', trackId)
-  await tracks.setUsedTracksAsNotCompleted(trackId)
+  tracks.setUsedTracksAsNotCompleted(trackId)
   tracks.removeFurtherUsedTracks(trackId)
 }
 </script>

--- a/packages/web/src/components/TeeTrack.vue
+++ b/packages/web/src/components/TeeTrack.vue
@@ -593,6 +593,10 @@ const saveSelectionFromSignal = (ev: any, index: number) => {
   saveSelection()
 }
 
+const resetSelections = () => {
+  selectedOptionsIndices.value = []
+  selectedOptions.value = []
+}
 
 const getButtonIcon = (index: number) => {
   const isActive = isActiveChoice(index)
@@ -608,9 +612,14 @@ const getButtonIcon = (index: number) => {
 
 // watchers
 watch(() => props.isCompleted, ( next ) => {
+  // console.log()
+  // console.log('TeeTrack > watch > props.trackId :', props.trackId )
   // console.log('TeeTrack > watch > isCompleted :', next )
   if (!next) {
-    selectedOptions.value = []
+    // console.log('TeeTrack > watch > selectionValues :', selectionValues )
+    if (noNeedForNext.includes(renderAs)) {
+      resetSelections()
+    }
     tracks.updateUsedTracks(props.trackId, props.step, next, selectedOptions.value)
   }
 })
@@ -619,7 +628,7 @@ watch(() => props.isCompleted, ( next ) => {
 
 const saveSelection = () => {
   // console.log()
-  // console.log('TeeTrack > updateStore > option :', option)
+  // console.log('TeeTrack > updateStore > selectedOptions.value :', selectedOptions.value)
 
   const optionNext = selectedOptions.value[0].next
   const nextExceptions = optionNext?.exceptions

--- a/packages/web/src/stores/tracks.ts
+++ b/packages/web/src/stores/tracks.ts
@@ -1,4 +1,5 @@
-import { ref, computed, toRaw } from 'vue'
+// import Vue from 'vue'
+import { ref, shallowRef, computed, toRaw } from 'vue'
 // cf : https://stackoverflow.com/questions/64917686/vue-array-converted-to-proxy-object
 import { defineStore } from 'pinia'
 
@@ -17,7 +18,7 @@ export const tracksStore = defineStore('tracks', () => {
   
   const maxDepth = ref(4)
 
-  const usedTracks = ref<UsedTrack[]>([])
+  const usedTracks = shallowRef<UsedTrack[]>([])
 
   // computed
   const tracksStepsArrayDict = computed(() => {
@@ -108,7 +109,9 @@ export const tracksStore = defineStore('tracks', () => {
   }
 
   // actions
-  function setMaxDepth(depth: number) { maxDepth.value = depth }
+  function setMaxDepth(depth: number) { 
+    maxDepth.value = depth
+  }
 
   function setSeedTrack(seed: string) {
     // console.log()
@@ -123,12 +126,14 @@ export const tracksStore = defineStore('tracks', () => {
     // console.log('store.tracks > addToUsedTracks > srcTrackId : ', srcTrackId)
     // console.log('store.tracks > addToUsedTracks > newTrackId : ', newTrackId)
 
+    const track = getTrack(srcTrackId)
+
     removeFurtherUsedTracks(srcTrackId)
 
     // add newTrackId
     const trackInfos: UsedTrack = {
       id: newTrackId,
-      category: undefined,
+      category: track?.category,
       completed: false,
       step: usedTracks.value.length + 1,
       selected: [],
@@ -146,13 +151,13 @@ export const tracksStore = defineStore('tracks', () => {
     // console.log('store.tracks > updateUsedTracks > selectedOptions : ', selectedOptions)
     usedTracks.value.map((trackInfo: UsedTrack) => {
       if (trackInfo.id === trackId) {
-        // console.log('store.tracks > updateUsedTracks > trackInfo : ', trackInfo)
-        // console.log('store.tracks > updateUsedTracks > trackInfo : ', trackInfo)
+        // console.log('store.tracks > updateUsedTracks > trackInfo (A) : ', trackInfo)
         const hasValues = Boolean(selectedOptions.length)
         const nextTrack = next
         trackInfo.selected = selectedOptions
         trackInfo.completed = hasValues
         trackInfo.next = hasValues ? nextTrack : null
+        // console.log('store.tracks > updateUsedTracks > trackInfo (B) : ', trackInfo)
       }
     })
   }
@@ -160,15 +165,19 @@ export const tracksStore = defineStore('tracks', () => {
   async function setUsedTracksAsNotCompleted(trackId: string) {
     // console.log()
     // console.log('store.tracks > setUsedTracksAsNotCompleted > trackId : ', trackId)
+    // console.log('store.tracks > setUsedTracksAsNotCompleted > updatedArray : ', updatedArray)
     usedTracks.value.map((trackInfo: UsedTrack) => {
+      // console.log('store.tracks > setUsedTracksAsNotCompleted > trackInfoCopy : ', trackInfoCopy)
       if (trackInfo.id === trackId) {
         trackInfo.completed = false
+        // console.log('store.tracks > setUsedTracksAsNotCompleted > trackInfo : ', trackInfo)
       }
+      return trackInfo
     })
     // console.log('store.tracks > setUsedTracksAsNotCompleted > usedTracks.value : ', usedTracks.value)
   }
 
-  function removeFurtherUsedTracks(srcTrackId: string) {
+  async function removeFurtherUsedTracks(srcTrackId: string) {
     // console.log()
     // console.log('store.tracks > removeFurtherUsedTracks > srcTrackId : ', srcTrackId)
     const lastTrack: UsedTrack | undefined = usedTracks.value.find((t: UsedTrack) => t.id === srcTrackId)


### PR DESCRIPTION
# Problème

Dans la version précédente de `preprod` quand on utilisait la _sidebar_ (fil d'Ariane) le comportement n'était pas satisfaisant : si on revenait en arrière avec la _sidebar_ il fallait alors re-cliquer deux fois sur un choix déjà sélectionné pour passer à la piste suivante... 

# Résultat attendu

Le comportement souhaité lors du retour en arrière au clic sur un des boutons de la _sidebar_ est le suivant : 

1. Je clique sur le bouton de la piste à laquelle je souhaite revenir dans la _sidebar_ ;
2. La piste de question voulue réapparaît avec : 
  - Le choix que j'avais précédemment choisi est déjà sélectionné ;
  - Le bouton 'Suivant'  est donc déjà actif ;
3. Je peux directement cliquer sur 'Suivant' :
  - Mon choix est enregistré ;
  - La nouvelle piste de question apparaît ;

# Correctifs

Ce comportement attendu n'était pas correctement codé. Ce _fix_ vient corriger le comportement des pistes et de la _sidebar_ pour que l'app ait bien le comportement attendu.

- Une des raisons principales de ce bug était l'utilisation de la classe `ref` dans le store Pinia sur une liste d'ojets, qui ne permettait pas de faire un update sur une clé précise d'un objet de la liste => Correctif : utilisation de `shallowRef` plutôt que `ref` pour l'objet `UsedTracks`

- L'autre correctif + mineur concerne certains types de pistes de questions (aka `renderAs` équivalent à `track?.interface.component`), qui demandent naturellement que la sélection de l'utilisateur soit effacée avant de passer à la piste de questions suivante (`noNeedForNext.includes(renderAs) === true`). Les pistes de type `cards` ou `simpleButtons` supposent de ne pas avoir de boutons "Précédent" et "Suivant". Lorsque l'utilisateur revient en arrière sur ce type de piste sa sélection précédente est effacée, et il n'a plus qu'à cliquer sur le bouton de son choix pour passer à la piste suivante.
 