### PR TITLE
CI: run unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Test program data against schema
+name: Run tests
 
 on:
   push:
@@ -24,3 +24,22 @@ jobs:
       - run: VERSION_AJV_CLI=`node -p -e "require('./packages/data/package.json').devDependencies[\"ajv-cli\"]"` npm install --no-package-lock --no-save ajv-cli@"$VERSION_AJV_CLI"
 
       - run: npm run test-data
+
+
+  unit-test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.12.0]
+#
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm clean-install
+
+      - run: npm run test -w packages/backend


### PR DESCRIPTION
Currently, unit tests are only run locally (with `npm run test -w packages/backend`).

This PR adds the unit tests in continuous integration to avoid shipping with failing tests.