### PR TITLE
fix: file rename broke the build procedure

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -33,7 +33,9 @@ npm run test-data
 
 The program type is firsthand generated from the json schema (cf `./src/generateProgramType.ts`).
 
-The original yaml files are by design incomplete. The content of `./common/constants.yaml` is appendend to each program's `publicodes` property. The data is then consolidated into `../web/public/data/generated/dataset_out.json`
+The original yaml files are by design incomplete. The content of `./common/interface.yaml` is appendend to each program's `publicodes` 
+property. The data is then consolidated into 
+`../web/public/data/generated/dataset_out.json`
 
 ```sh
 # From this folder

--- a/packages/data/src/buildJsonOutput.ts
+++ b/packages/data/src/buildJsonOutput.ts
@@ -51,11 +51,11 @@ const readPrograms = (): any[] => {
   return programs
 }
 
-/** Prepends publicodes with constants common to all programs (stored in
- * "packages/data/common/constants.yaml")
+/** Prepends publicodes with a publicodes snippet common to all programs (stored in
+ * "packages/data/common/interface.yaml")
  */
 const prependConstants = (programs: Program[]): Program[] => {
-  const CONSTANTS_PATH = './../common/constants.yaml'
+  const CONSTANTS_PATH = './../common/interface.yaml'
 
   const fullPath: string = path.join(__dirname, CONSTANTS_PATH)
 


### PR DESCRIPTION
A [last minute file rename](https://github.com/betagouv/transition-ecologique-entreprises-widget/pull/133/commits/b8afdb305d95a653dccb848badb0be2e83214e7d) broke the build procedure. 

This PR fixes the file name references (along with doc rewording).