### PR TITLE
fix: stop the nodemon generation madness

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -4,7 +4,7 @@
   "description": "Package in charge of storing and building TEE datasets",
   "scripts": {
     "build-json-output": "npx ts-node src/generateProgramType.ts && npx ts-node src/buildJsonOutput.ts",
-    "build-json-output-watch": "npx ts-node src/generateProgramType.ts && npx concurrently \"nodemon src/generateProgramType.ts --ignore *.d.ts -e ts,yaml\" \"nodemon src/buildJsonOutput.ts -e ts,yaml\"",
+    "build-json-output-watch": "nodemon --exec \"npx ts-node src/generateProgramType.ts && npx ts-node src/buildJsonOutput.ts\" --ext yaml,json,ts --ignore src/generated ",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
The `build-json-output-watch` was launching two nodemon concurrently, and `npm run dev-front` would throw a third. As `generateProgramType.ts` and `buildJsonOutput.ts` were generating files, nodemon would restart two or three times each service before arriving at a stable state. 

I replaced the call to `concurrently` with a sequential call to `generateProgramType.ts`  followed by `buildJsonOutput.ts`.

Benefits : 
- More readable, shorter script
- No more script triggering the other
- We had to run them sequentially at least for the first generation, so now this is guaranteed. 

Drawbacks : 
- Program type is regenerated at each change, even though most changes are completely unrelated. But it does not take long, so... who cares ?