### PR TITLE
hotfix: filtering problem in "Je ne sais pas par où commencer" 

### DIFF
--- a/packages/backend/src/domain/eligibility.ts
+++ b/packages/backend/src/domain/eligibility.ts
@@ -35,17 +35,9 @@ export const filterPrograms = (
 ): Result<ProgramData[], Error> => {
   const eligibilityResults = programs.map((p) => evaluateRule(p.publicodes, inputData))
 
-  for (const r of eligibilityResults) {
-    if (r.isErr) {
-      return Result.err(r.error)
-    }
-
-    const isUndefined = r.isOk && typeof r.value === 'undefined'
-
-    if (isUndefined) {
-      return Result.err(
-        new Error(`"${FILTERING_RULE_NAME}" is undefined (probably because of missing input data)`)
-      )
+  for (const e of eligibilityResults) {
+    if (e.isErr) {
+      return Result.err(e.error)
     }
   }
 
@@ -53,8 +45,9 @@ export const filterPrograms = (
     const e = evaluateRule(p.publicodes, inputData)
 
     const isPositive = e.isOk && e.value
+    const isUndefined = e.isOk && typeof e.value === 'undefined'
 
-    return isPositive
+    return isPositive || isUndefined
   })
 
   return Result.ok(filteredPrograms)

--- a/packages/backend/tests/eligibilite.test.ts
+++ b/packages/backend/tests/eligibilite.test.ts
@@ -129,7 +129,7 @@ EXPECT that the filtering only keeps programs that are eligible (rule
 describe(`
   GIVEN  a list of programs
   WHEN   the data does not allow to fully evaluate the eligibility rule (missing data)
-  EXPECT that filterPrograms returns an error
+  EXPECT that filterPrograms does not filter out the programs
 `, () => {
   test('undefined rule', () => {
     const programs = [makeProgram(rulesBoilerplate)]
@@ -137,8 +137,8 @@ describe(`
 
     const result = filterPrograms(programs, inputData)
 
-    expectToBeErr(result)
-    // expect(result.value.length).toBe(1)
+    expectToBeOk(result)
+    expect(result.value.length).toBe(1)
   })
 })
 


### PR DESCRIPTION
To avoid unnoticed filtering problems, publicodes would require to have all variables defined when evaluating a rule, or otherwise throw an error. 

However, if filtering problems are not noticed in preproduction, then the final user gets the error, which is not the best ID. In particular, we missed that in the "Je ne sais pas par où commencer" route was not defining the `questionnaire . objectif prioritaire` property, used to filter some programs. 

This hotfix allows to have undefined publicodes rules. The introduced behavior is to keep the programs with undefined `afficher à l'utilisateur si` rule. 