### PR TITLE
feat[data]: Add filtering on priority NAF code

### DIFF
--- a/packages/data/common/interface.yaml
+++ b/packages/data/common/interface.yaml
@@ -11,7 +11,7 @@ entreprise . secteur d'activité:
     est artisanat:
     est autre secteur:
 
-entreprise . code NAF:
+entreprise . code NAF niveau 1:
   avec:
     est A:
     est B:

--- a/packages/data/programs/accelerateur-decarbonation.yaml
+++ b/packages/data/programs/accelerateur-decarbonation.yaml
@@ -30,27 +30,27 @@ publicodes:
     - entreprise . effectif >= 50
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est mon impact environnemental

--- a/packages/data/programs/aides-au-reemploi-des-emballages.yaml
+++ b/packages/data/programs/aides-au-reemploi-des-emballages.yaml
@@ -34,24 +34,24 @@ publicodes:
     - est dans les objectifs de l'entreprise
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/audits-de-certification-labelisation.yaml
+++ b/packages/data/programs/audits-de-certification-labelisation.yaml
@@ -29,7 +29,7 @@ publicodes:
     - entreprise . effectif <= 499
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est I
+    - entreprise . code NAF niveau 1 . est I
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est mon impact environnemental

--- a/packages/data/programs/booster-eco-energie-tertiaire.yaml
+++ b/packages/data/programs/booster-eco-energie-tertiaire.yaml
@@ -50,19 +50,19 @@ publicodes:
     - entreprise . effectif <= 4999
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/conseillers-renovation-petit-tertiaire-prive.yaml
+++ b/packages/data/programs/conseillers-renovation-petit-tertiaire-prive.yaml
@@ -29,22 +29,22 @@ publicodes:
     - entreprise . effectif <= 250
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/diag-decarbon-action-2.yaml
+++ b/packages/data/programs/diag-decarbon-action-2.yaml
@@ -31,16 +31,16 @@ publicodes:
     - entreprise . effectif <= 499
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est R
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est R
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est ma performance énergétique

--- a/packages/data/programs/diag-decarbon-action.yaml
+++ b/packages/data/programs/diag-decarbon-action.yaml
@@ -30,16 +30,16 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est R
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est R
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est ma performance énergétique

--- a/packages/data/programs/diag-eco-flux-2.yaml
+++ b/packages/data/programs/diag-eco-flux-2.yaml
@@ -31,17 +31,17 @@ publicodes:
     - entreprise . effectif <= 250
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est Q
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est Q
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/diag-eco-flux.yaml
+++ b/packages/data/programs/diag-eco-flux.yaml
@@ -31,17 +31,17 @@ publicodes:
     - entreprise . effectif <= 49
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est Q
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est Q
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/diag-ecoconception-2.yaml
+++ b/packages/data/programs/diag-ecoconception-2.yaml
@@ -31,15 +31,15 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/diag-ecoconception.yaml
+++ b/packages/data/programs/diag-ecoconception.yaml
@@ -31,15 +31,15 @@ publicodes:
     - entreprise . effectif <= 49
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/diag-impact.yaml
+++ b/packages/data/programs/diag-impact.yaml
@@ -28,13 +28,13 @@ publicodes:
     - entreprise . effectif <= 250
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est S
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est S
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est mon impact environnemental

--- a/packages/data/programs/diag-perf-immo.yaml
+++ b/packages/data/programs/diag-perf-immo.yaml
@@ -30,24 +30,24 @@ publicodes:
     - entreprise . effectif >= 1
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/diagnostic-rse-responsabilite-societale-des-entreprises.yaml
+++ b/packages/data/programs/diagnostic-rse-responsabilite-societale-des-entreprises.yaml
@@ -29,23 +29,23 @@ publicodes:
     - entreprise . effectif <= 499
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est former ou recruter

--- a/packages/data/programs/diagnostic-transition-ecologique-tpe-pme.yaml
+++ b/packages/data/programs/diagnostic-transition-ecologique-tpe-pme.yaml
@@ -29,21 +29,21 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est mon impact environnemental

--- a/packages/data/programs/eco-defis-des-artisans-et-des-commercants.yaml
+++ b/packages/data/programs/eco-defis-des-artisans-et-des-commercants.yaml
@@ -29,9 +29,9 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est I
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est I
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/enviroveille.yaml
+++ b/packages/data/programs/enviroveille.yaml
@@ -32,15 +32,15 @@ publicodes:
     - entreprise . effectif <= 499
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q

--- a/packages/data/programs/etude-de-faisabilite-d-installation-solaire-thermique.yaml
+++ b/packages/data/programs/etude-de-faisabilite-d-installation-solaire-thermique.yaml
@@ -42,27 +42,27 @@ publicodes:
     - est dans les objectifs de l'entreprise
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est ma performance énergétique

--- a/packages/data/programs/etudes-ademe-diagnostic-serres.yaml
+++ b/packages/data/programs/etudes-ademe-diagnostic-serres.yaml
@@ -31,7 +31,7 @@ publicodes:
     - entreprise . effectif >= 250
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
+    - entreprise . code NAF niveau 1 . est A
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/etudes-ademe-economie-de-la-fonctionnalite.yaml
+++ b/packages/data/programs/etudes-ademe-economie-de-la-fonctionnalite.yaml
@@ -34,26 +34,26 @@ publicodes:
     - est dans les objectifs de l'entreprise
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/etudes-ademe-gaspillage-alimentaire.yaml
+++ b/packages/data/programs/etudes-ademe-gaspillage-alimentaire.yaml
@@ -38,11 +38,11 @@ publicodes:
     - est dans les objectifs de l'entreprise
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est I
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est I
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/etudes-ademe-performance-produits.yaml
+++ b/packages/data/programs/etudes-ademe-performance-produits.yaml
@@ -25,9 +25,9 @@ publicodes:
     - est dans les objectifs de l'entreprise
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est J
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est J
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/etudes-ademe-photovoltaique.yaml
+++ b/packages/data/programs/etudes-ademe-photovoltaique.yaml
@@ -34,27 +34,27 @@ publicodes:
     - est dans les objectifs de l'entreprise
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/financement-ademe-investissements-chaleur.yaml
+++ b/packages/data/programs/financement-ademe-investissements-chaleur.yaml
@@ -28,19 +28,19 @@ publicodes:
     - est dans les objectifs de l'entreprise
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/financement-ademe-investissements-d-ecoconception.yaml
+++ b/packages/data/programs/financement-ademe-investissements-d-ecoconception.yaml
@@ -36,9 +36,9 @@ publicodes:
     - est dans les objectifs de l'entreprise
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est J
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est J
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/fonds-tourisme-durable.yaml
+++ b/packages/data/programs/fonds-tourisme-durable.yaml
@@ -43,8 +43,8 @@ publicodes:
     - entreprise . effectif <= 250
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est I
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est I
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/formations-actions-baisse-les-watts.yaml
+++ b/packages/data/programs/formations-actions-baisse-les-watts.yaml
@@ -27,11 +27,11 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est S
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est S
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est ma performance énergétique

--- a/packages/data/programs/formations-du-cfde.yaml
+++ b/packages/data/programs/formations-du-cfde.yaml
@@ -30,18 +30,18 @@ publicodes:
     - entreprise . effectif <= 499
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est former ou recruter

--- a/packages/data/programs/imprim-vert.yaml
+++ b/packages/data/programs/imprim-vert.yaml
@@ -38,7 +38,7 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
+    - entreprise . code NAF niveau 1 . est C
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/mission-strategie-environnement.yaml
+++ b/packages/data/programs/mission-strategie-environnement.yaml
@@ -30,27 +30,27 @@ publicodes:
     - entreprise . effectif >= 10
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est former ou recruter

--- a/packages/data/programs/performa-environnement.yaml
+++ b/packages/data/programs/performa-environnement.yaml
@@ -31,11 +31,11 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est I
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est I
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/pret-action-climat.yaml
+++ b/packages/data/programs/pret-action-climat.yaml
@@ -31,27 +31,27 @@ publicodes:
     - entreprise . effectif <= 49
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/pret-economies-d-energie-pee.yaml
+++ b/packages/data/programs/pret-economies-d-energie-pee.yaml
@@ -25,27 +25,27 @@ publicodes:
     - entreprise . effectif <= 49
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est K
-    - entreprise . code NAF . est L
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est O
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
-    - entreprise . code NAF . est T
-    - entreprise . code NAF . est U
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est K
+    - entreprise . code NAF niveau 1 . est L
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est O
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
+    - entreprise . code NAF niveau 1 . est T
+    - entreprise . code NAF niveau 1 . est U
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est ma performance énergétique

--- a/packages/data/programs/programme-synergies-durables-economie-circulaire.yaml
+++ b/packages/data/programs/programme-synergies-durables-economie-circulaire.yaml
@@ -29,16 +29,16 @@ publicodes:
     - entreprise . effectif <= 499
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est M
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est M
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/repar-acteurs.yaml
+++ b/packages/data/programs/repar-acteurs.yaml
@@ -30,7 +30,7 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est G
+    - entreprise . code NAF niveau 1 . est G
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/tpe-gagnantes-sur-tous-les-couts.yaml
+++ b/packages/data/programs/tpe-gagnantes-sur-tous-les-couts.yaml
@@ -29,11 +29,11 @@ publicodes:
     - entreprise . effectif <= 19
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la gestion des déchets

--- a/packages/data/programs/tremplin.yaml
+++ b/packages/data/programs/tremplin.yaml
@@ -27,15 +27,15 @@ publicodes:
     - entreprise . effectif <= 250
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est G
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est J
-    - entreprise . code NAF . est M
-    - entreprise . code NAF . est N
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est G
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est J
+    - entreprise . code NAF niveau 1 . est M
+    - entreprise . code NAF niveau 1 . est N
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est la mobilité durable

--- a/packages/data/programs/visite-energie-2.yaml
+++ b/packages/data/programs/visite-energie-2.yaml
@@ -30,10 +30,10 @@ publicodes:
     - entreprise . effectif <= 249
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est I
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est I
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est rénover mon bâtiment

--- a/packages/data/programs/visite-energie.yaml
+++ b/packages/data/programs/visite-energie.yaml
@@ -32,18 +32,18 @@ publicodes:
     - entreprise . effectif <= 499
   secteur d'activité prioritaire:
     une de ces conditions:
-    - entreprise . code NAF . est A
-    - entreprise . code NAF . est B
-    - entreprise . code NAF . est C
-    - entreprise . code NAF . est D
-    - entreprise . code NAF . est E
-    - entreprise . code NAF . est F
-    - entreprise . code NAF . est H
-    - entreprise . code NAF . est I
-    - entreprise . code NAF . est P
-    - entreprise . code NAF . est Q
-    - entreprise . code NAF . est R
-    - entreprise . code NAF . est S
+    - entreprise . code NAF niveau 1 . est A
+    - entreprise . code NAF niveau 1 . est B
+    - entreprise . code NAF niveau 1 . est C
+    - entreprise . code NAF niveau 1 . est D
+    - entreprise . code NAF niveau 1 . est E
+    - entreprise . code NAF niveau 1 . est F
+    - entreprise . code NAF niveau 1 . est H
+    - entreprise . code NAF niveau 1 . est I
+    - entreprise . code NAF niveau 1 . est P
+    - entreprise . code NAF niveau 1 . est Q
+    - entreprise . code NAF niveau 1 . est R
+    - entreprise . code NAF niveau 1 . est S
   est dans les objectifs de l'entreprise:
     une de ces conditions:
     - questionnaire . objectif prioritaire . est ma performance énergétique

--- a/packages/data/schemas/tools/XL2yaml/XL2yaml.py
+++ b/packages/data/schemas/tools/XL2yaml/XL2yaml.py
@@ -9,7 +9,7 @@ import pylightxl
 import yaml
 
 INPUT_XL_FILE = "./dispositifs.xlsx"
-WORKSHEET = "Data"
+WORKSHEET = "DataProd"
 SKIP_XL_LINES = 5
 OUTPUT_DIR = "../../../programs"
 
@@ -213,7 +213,7 @@ def pc_secteurActivitéConstraint(rawData, colNumbers):
 
     return {
         "une de ces conditions": [
-            f"entreprise . code NAF . est {s[0]}"
+            f"entreprise . code NAF niveau 1 . est {s[0]}"
             for s, keep in zip(secteurs, secteursInd)
             if keep
         ]

--- a/packages/web/src/questionnaire/publicodesObjects.ts
+++ b/packages/web/src/questionnaire/publicodesObjects.ts
@@ -30,7 +30,7 @@ export const SecteurByNAF = {
 export const objectifsPrioritaires = {
   'questionnaire . objectif prioritaire . est mon impact environnemental': 'non',
   'questionnaire . objectif prioritaire . est ma performance énergétique': 'non',
-  "questionnaire . objectif prioritaire . est est diminuer ma consommation d'eau": 'non',
+  "questionnaire . objectif prioritaire . est diminuer ma consommation d'eau": 'non',
   'questionnaire . objectif prioritaire . est rénover mon bâtiment': 'non',
   'questionnaire . objectif prioritaire . est la mobilité durable': 'non',
   'questionnaire . objectif prioritaire . est la gestion des déchets': 'non',

--- a/packages/web/src/questionnaire/publicodesObjects.ts
+++ b/packages/web/src/questionnaire/publicodesObjects.ts
@@ -1,0 +1,39 @@
+// LEGACY
+export const secteurs = {
+  "entreprise . secteur d'activité . est artisanat": 'non',
+  "entreprise . secteur d'activité . est industrie": 'non',
+  "entreprise . secteur d'activité . est tourisme": 'non',
+  "entreprise . secteur d'activité . est tertiaire": 'non',
+  "entreprise . secteur d'activité . est agriculture": 'non',
+  "entreprise . secteur d'activité . est autre secteur": 'non'
+}
+
+// NAF CODES
+// Associates a NAF1 (composed of 1 letter) to its expected publicode variable
+export const NAF1ToVar = (letter: string): string => `entreprise . code NAF niveau 1 . est ${letter}`
+
+export const NAF1Letters = [...'ABCDEFGHIJKLMNOPQRSTU'] as const
+
+// publicodes variable initialization to "non"
+export const codesNAF1 = Object.fromEntries(NAF1Letters.map((l) => [NAF1ToVar(l), 'non']))
+
+export const SecteurByNAF = {
+  'artisanat': ['C', 'E', 'F', 'H', 'I'],
+  'industrie': ['B', 'C', 'D', 'E', 'F'],
+  'tourisme': ['A', 'I'],
+  'tertiaire': ['G','H','I','J','K','L','M','N','O','P','Q','R','S'],
+  'agriculture': ['A'],
+  'autre secteur': ['T', 'U'],
+}
+
+// OBJECTIFS
+export const objectifsPrioritaires = {
+  'questionnaire . objectif prioritaire . est mon impact environnemental': 'non',
+  'questionnaire . objectif prioritaire . est ma performance énergétique': 'non',
+  "questionnaire . objectif prioritaire . est est diminuer ma consommation d'eau": 'non',
+  'questionnaire . objectif prioritaire . est rénover mon bâtiment': 'non',
+  'questionnaire . objectif prioritaire . est la mobilité durable': 'non',
+  'questionnaire . objectif prioritaire . est la gestion des déchets': 'non',
+  "questionnaire . objectif prioritaire . est l'écoconception": 'non',
+  'questionnaire . objectif prioritaire . est former ou recruter': 'non'
+}

--- a/packages/web/src/questionnaire/trackGoals.ts
+++ b/packages/web/src/questionnaire/trackGoals.ts
@@ -1,13 +1,15 @@
-const objectifsPrioritaires = {
-  'questionnaire . objectif prioritaire . est mon impact environnemental': 'non',
-  'questionnaire . objectif prioritaire . est ma performance énergétique': 'non',
-  "questionnaire . objectif prioritaire . est est diminuer ma consommation d'eau": 'non',
-  'questionnaire . objectif prioritaire . est rénover mon bâtiment': 'non',
-  'questionnaire . objectif prioritaire . est la mobilité durable': 'non',
-  'questionnaire . objectif prioritaire . est la gestion des déchets': 'non',
-  "questionnaire . objectif prioritaire . est l'écoconception": 'non',
-  'questionnaire . objectif prioritaire . est former ou recruter': 'non'
-}
+import { objectifsPrioritaires } from './publicodesObjects'
+
+// const objectifsPrioritaires = {
+//   'questionnaire . objectif prioritaire . est mon impact environnemental': 'non',
+//   'questionnaire . objectif prioritaire . est ma performance énergétique': 'non',
+//   "questionnaire . objectif prioritaire . est est diminuer ma consommation d'eau": 'non',
+//   'questionnaire . objectif prioritaire . est rénover mon bâtiment': 'non',
+//   'questionnaire . objectif prioritaire . est la mobilité durable': 'non',
+//   'questionnaire . objectif prioritaire . est la gestion des déchets': 'non',
+//   "questionnaire . objectif prioritaire . est l'écoconception": 'non',
+//   'questionnaire . objectif prioritaire . est former ou recruter': 'non'
+// }
 
 export const goals = {
   id: 'track_goals',

--- a/packages/web/src/questionnaire/trackGoals.ts
+++ b/packages/web/src/questionnaire/trackGoals.ts
@@ -61,7 +61,7 @@ export const goals = {
     {
       value: {
         ...objectifsPrioritaires,
-        "questionnaire . objectif prioritaire . est est diminuer ma consommation d'eau": 'oui'
+        "questionnaire . objectif prioritaire . est diminuer ma consommation d'eau": 'oui'
       },
       title: { fr: "Gestion de l'eau" },
       label: { fr: "💧 Diminuer ma consommation d'eau" },

--- a/packages/web/src/questionnaire/trackSectors.ts
+++ b/packages/web/src/questionnaire/trackSectors.ts
@@ -1,11 +1,13 @@
-const secteurs = {
-  "entreprise . secteur d'activité . est artisanat": 'non',
-  "entreprise . secteur d'activité . est industrie": 'non',
-  "entreprise . secteur d'activité . est tourisme": 'non',
-  "entreprise . secteur d'activité . est tertiaire": 'non',
-  "entreprise . secteur d'activité . est agriculture": 'non',
-  "entreprise . secteur d'activité . est autre secteur": 'non'
-}
+import { secteurs, SecteurByNAF, NAF1ToVar, codesNAF1 } from './publicodesObjects'
+
+// const secteurs = {
+//   "entreprise . secteur d'activité . est artisanat": 'non',
+//   "entreprise . secteur d'activité . est industrie": 'non',
+//   "entreprise . secteur d'activité . est tourisme": 'non',
+//   "entreprise . secteur d'activité . est tertiaire": 'non',
+//   "entreprise . secteur d'activité . est agriculture": 'non',
+//   "entreprise . secteur d'activité . est autre secteur": 'non'
+// }
 
 const nextExceptions = [
   {
@@ -46,6 +48,15 @@ const nextExceptions = [
   }
 ]
 
+// const test = { ...codesNAF1 }
+// const test = SecteurByNAF['artisanat'].map((l) => { return { [NAF1ToVar(l)]: 'oui' } })
+// const test = {
+//   'test': 'yes',
+//   ...Object.assign({}, ...SecteurByNAF['artisanat'].map((l) => { return { [NAF1ToVar(l)]: 'oui' }} ))
+// }
+// console.log(test)
+
+
 export const sectors = {
   id: 'track_sectors',
   help: 'https://www.insee.fr/fr/metadonnees/nafr2',
@@ -63,7 +74,9 @@ export const sectors = {
       value: {
           secteur: 'Artisanat',
           ...secteurs, 
-          "entreprise . secteur d'activité . est artisanat": 'oui' 
+          "entreprise . secteur d'activité . est artisanat": 'oui',
+          // "entreprise . code NAF niveau 1 . est A": 'oui'
+          ...Object.assign({}, ...SecteurByNAF['artisanat'].map((l) => { return { [NAF1ToVar(l)]: 'oui' } }))
       },
       title: { fr: 'Artisanat' },
       label: { fr: '👩‍🎨 J’ai une activité artisanale' },
@@ -76,7 +89,9 @@ export const sectors = {
       value: {
           secteur: 'Industrie',
           ...secteurs, 
-          "entreprise . secteur d'activité . est industrie": 'oui' 
+          "entreprise . secteur d'activité . est industrie": 'oui',
+          ...codesNAF1,
+          ...Object.assign({}, ...SecteurByNAF['industrie'].map((l) => { return { [NAF1ToVar(l)]: 'oui' } }))
       },
       title: { fr: 'Industrie' },
       label: { fr: '👩‍🔧 J’ai une activité industrielle, fabrication, production' },
@@ -89,7 +104,9 @@ export const sectors = {
       value: {
           secteur: 'Tourisme',
           ...secteurs, 
-          "entreprise . secteur d'activité . est tourisme": 'oui' 
+          "entreprise . secteur d'activité . est tourisme": 'oui',
+          ...codesNAF1,
+          ...Object.assign({}, ...SecteurByNAF['tourisme'].map((l) => { return { [NAF1ToVar(l)]: 'oui' } }))
       },
       title: { fr: 'Tourisme' },
       label: { fr: '🤵‍♂️ J’ai une activité de tourisme, restauration' },
@@ -102,7 +119,9 @@ export const sectors = {
       value: {
           secteur: 'Tertiaire',
           ...secteurs, 
-          "entreprise . secteur d'activité . est tertiaire": 'oui' 
+          "entreprise . secteur d'activité . est tertiaire": 'oui',
+          ...codesNAF1,
+          ...Object.assign({}, ...SecteurByNAF['tertiaire'].map((l) => { return { [NAF1ToVar(l)]: 'oui' } }))
       },
       title: { fr: 'Tertiaire' },
       label: { fr: '🧑‍⚖️ J’ai une activité tertiaire, de services' },
@@ -115,7 +134,9 @@ export const sectors = {
       value: {
           secteur: 'Agriculture',
           ...secteurs, 
-          "entreprise . secteur d'activité . est agriculture": 'oui' 
+          "entreprise . secteur d'activité . est agriculture": 'oui',
+          ...codesNAF1,
+          ...Object.assign({}, ...SecteurByNAF['agriculture'].map((l) => { return { [NAF1ToVar(l)]: 'oui' } }))
       },
       title: { fr: 'Agriculture' },
       label: { fr: '👩‍🌾 J’ai une activité agricole' },
@@ -128,7 +149,9 @@ export const sectors = {
       value: {
           secteur: 'Autre',
           ...secteurs, 
-          "entreprise . secteur d'activité . est autre secteur": 'oui' 
+          "entreprise . secteur d'activité . est autre secteur": 'oui',
+          ...codesNAF1,
+          ...Object.assign({}, ...SecteurByNAF['autre secteur'].map((l) => { return { [NAF1ToVar(l)]: 'oui' } }))
       },
       title: { fr: 'Autre' },
       label: { fr: "Je suis dans un autre secteur d'activité" },
@@ -139,3 +162,5 @@ export const sectors = {
     }
   ]
 }
+
+// console.log(sectors)

--- a/packages/web/src/questionnaire/trackSiret.ts
+++ b/packages/web/src/questionnaire/trackSiret.ts
@@ -1,23 +1,25 @@
+import { secteurs, NAF1ToVar, NAF1Letters, codesNAF1 } from './publicodesObjects'
+
 const metaEnv = import.meta.env
 // console.log('trackSiret >  metaEnv :', metaEnv)
 const TEE_BACKEND_URL = metaEnv.VITE_TEE_BACKEND_URL || 'https://tee-backend.osc-fr1.scalingo.io'
 
-const secteurs = {
-  "entreprise . secteur d'activité . est artisanat": 'non',
-  "entreprise . secteur d'activité . est industrie": 'non',
-  "entreprise . secteur d'activité . est tourisme": 'non',
-  "entreprise . secteur d'activité . est tertiaire": 'non',
-  "entreprise . secteur d'activité . est agriculture": 'non',
-  "entreprise . secteur d'activité . est autre secteur": 'non'
-}
+// const secteurs = {
+//   "entreprise . secteur d'activité . est artisanat": 'non',
+//   "entreprise . secteur d'activité . est industrie": 'non',
+//   "entreprise . secteur d'activité . est tourisme": 'non',
+//   "entreprise . secteur d'activité . est tertiaire": 'non',
+//   "entreprise . secteur d'activité . est agriculture": 'non',
+//   "entreprise . secteur d'activité . est autre secteur": 'non'
+// }
 
 // Associates a NAF1 (composed of 1 letter) to its expected publicode variable
-const NAF1ToVar = (letter: string): string => `entreprise . code NAF niveau 1 . est ${letter}`
+// const NAF1ToVar = (letter: string): string => `entreprise . code NAF niveau 1 . est ${letter}`
 
-const NAF1Letters = [...'ABCDEFGHIJKLMNOPQRSTU'] as const
+// const NAF1Letters = [...'ABCDEFGHIJKLMNOPQRSTU'] as const
 
-// publicodes variable initialization to "non"
-const codesNAF1 = Object.fromEntries(NAF1Letters.map((l) => [NAF1ToVar(l), 'non']))
+// // publicodes variable initialization to "non"
+// const codesNAF1 = Object.fromEntries(NAF1Letters.map((l) => [NAF1ToVar(l), 'non']))
 
 const dataTarget = {
   siret: '',

--- a/packages/web/src/questionnaire/trackSiret.ts
+++ b/packages/web/src/questionnaire/trackSiret.ts
@@ -12,7 +12,7 @@ const secteurs = {
 }
 
 // Associates a NAF1 (composed of 1 letter) to its expected publicode variable
-const NAF1ToVar = (letter: string): string => `entreprise . code NAF . est ${letter}`
+const NAF1ToVar = (letter: string): string => `entreprise . code NAF niveau 1 . est ${letter}`
 
 const NAF1Letters = [...'ABCDEFGHIJKLMNOPQRSTU'] as const
 


### PR DESCRIPTION
### Context

#155 uses the columns BZ1 to CT1 in the progam data XL file to include in the publicodes filtering rules of each program a rule named `secteur d'activité prioritaire`.

These rules are currently evaluated to `undefined` as the variables are not injected in the expected format, so the filtering does not occur. 

It is the aim of this PR to make the link between the questionnaire and the rules, to have a real filtering on level 1 NAF code. 

### Details

As discussed, the typing is a bit superficial, as we probably wanna find a generic solution for the generation of publicodes variables, i.e transform `code NAF = "A" ...` into a (preferably typed) object `{ code NAF . est A: "oui", code NAF . est B: "non", etc. }`. Right now, the questionnaire fills an object of the latter form.

The filtering only occurs when the user has entered its `SIRET`, otherwise the NAF code is unknown and no filtering occurs on this variable. Moreover, the question about the activity sector that is triggered when the user does not enter the `SIRET` is not used during filtering. 

The procedure has been copied from the similar `secteur` procedure. 

`NAF1` naming refers to `NAF code level 1`.  

> L’Insee dispose d’un outil de [recherche de nomenclature d’activité française](http://www.insee.fr/fr/methodes/default.asp?page=nomenclatures/naf2008/liste_n1.htm) (NAF) pour déterminer son code. Cette recherche peut s’effectuer par des niveaux appelés « listes » de plus en plus détaillés.

- [x] Rename `code NAF` to `code NAF niveau 1` in data and interface

Currently only manually tested.

/!\ This PR builds upon `p-add-programs` and will require to be rebased after (squashing and) merging the related PR. 
