### PR TITLE
PR - feat: add aid info in miniature cards

### DIFF
--- a/packages/web/public/css/custom.css
+++ b/packages/web/public/css/custom.css
@@ -164,6 +164,11 @@ WARNING :
 }
 .tee-program-resume {
   color: #000091; 
+  font-size: 1.7rem;
+  line-height: 2rem;
+}
+.tee-program-info {
+  color: #000091; 
 }
 .tee-program-badge-image {
   text-transform: inherit;

--- a/packages/web/src/assets/custom.css
+++ b/packages/web/src/assets/custom.css
@@ -164,6 +164,11 @@ WARNING :
 }
 .tee-program-resume {
   color: #000091; 
+  font-size: 1.7rem;
+  line-height: 2rem;
+}
+.tee-program-info {
+  color: #000091; 
 }
 .tee-program-badge-image {
   text-transform: inherit;

--- a/packages/web/src/components/TeeResults.vue
+++ b/packages/web/src/components/TeeResults.vue
@@ -45,9 +45,20 @@
       @click="updateDetailResult(prog.id)">
       <div class="fr-card__body">
         <div class="fr-card__content">
-          <h2 class="fr-card__title tee-program-resume">
+          <!-- TITLE -->
+          <div class="fr-card__start fr-mb-2v">
+            <p 
+              class="tee-program-title">
+              {{ prog.titre }}
+            </p>
+          </div>
+          <!-- CONTENT -->
+          <h2 
+            class="fr-card__title tee-program-resume fr-mb-3v"
+            style="font-size: 1.7rem;">
             {{ prog.promesse }} 
           </h2>
+          <!-- DEBUG -->
           <p
             v-if="debug"
             class="vue-debug fr-card__desc">
@@ -55,16 +66,11 @@
             <br> prog.cover : <code>{{ prog.illustration }}</code>
             <!-- {{ `${choices.publicPath}${randomImage()}` }} -->
           </p>
-          <!-- TITLE -->
-          <div class="fr-card__start">
-            <p 
-              class="fr-mb-3v tee-program-title">
-              {{ prog.titre }}
-            </p>
-          </div>
+          <!-- END -->
           <div class="fr-card__end">
             <p 
-              class="fr-mb-0">
+              class="fr-mb-0"
+              style="color: #000091;">
               <span 
                 class="fr-icon-money-euro-circle-line" 
                 aria-hidden="true">

--- a/packages/web/src/components/TeeResults.vue
+++ b/packages/web/src/components/TeeResults.vue
@@ -62,6 +62,17 @@
               {{ prog.titre }}
             </p>
           </div>
+          <div class="fr-card__end">
+            <p 
+              class="fr-mb-0">
+              <span 
+                class="fr-icon-money-euro-circle-line" 
+                aria-hidden="true">
+              </span>
+              {{ choices.t(getCostInfosPrefix(prog)) }} :
+              {{ getCostInfosText(prog) }}
+            </p>
+          </div>
         </div>
       </div>
       <div
@@ -151,6 +162,46 @@ const resultsProgsLen = computed(() => {
 const updateDetailResult = (id: string | number) => {
   // console.log(`TeeResults > updateDetailResult >  id : ${id}`)
   programs.setDetailResult(id, props.trackId)
+}
+
+interface costInfos {
+  prefix: string
+  text: string | undefined
+}
+const getCostInfos = (program: ProgramData) => {
+  let obj: costInfos = {
+    prefix: '',
+    text: ''
+  }
+  // console.log('TeeResults > onBeforeMount > resultsProgs :', resultsProgs )
+  switch (program["nature de l'aide"]) {
+    case 'accompagnement':
+      obj.prefix = 'programCosts.costPrefix'
+      obj.text = program["coût de l'accompagnement"]
+      break
+    case 'formation':
+      obj.prefix = 'programCosts.costPrefix'
+      obj.text = program["coût de l'accompagnement"]
+      break
+    case 'financement':
+      obj.prefix = 'programCosts.aidPrefix'
+      obj.text = program['montant du financement']
+      break
+    case 'prêt':
+      obj.prefix = 'programCosts.loan'
+      obj.text = program['montant du prêt']
+      break
+  }
+  return obj
+}
+
+const getCostInfosPrefix = (program: ProgramData) => {
+  const infos = getCostInfos(program)
+  return infos?.prefix
+}
+const getCostInfosText = (program: ProgramData) => {
+  const infos = getCostInfos(program)
+  return infos?.text
 }
 
 

--- a/packages/web/src/components/TeeResults.vue
+++ b/packages/web/src/components/TeeResults.vue
@@ -54,8 +54,7 @@
           </div>
           <!-- CONTENT -->
           <h2 
-            class="fr-card__title tee-program-resume fr-mb-3v"
-            style="font-size: 1.7rem; line-height: 2rem;">
+            class="fr-card__title tee-program-resume fr-mb-3v">
             {{ prog.promesse }} 
           </h2>
           <!-- DEBUG -->
@@ -69,14 +68,12 @@
           <!-- END -->
           <div class="fr-card__end">
             <p 
-              class="fr-mb-0"
-              style="color: #000091;">
+              class="fr-mb-0 tee-program-info">
               <span 
                 class="fr-icon-money-euro-circle-line" 
                 aria-hidden="true">
               </span>
-              {{ choices.t(getCostInfosPrefix(prog)) }} :
-              {{ getCostInfosText(prog) }}
+              {{ getCostInfos(prog) }}
             </p>
           </div>
         </div>
@@ -134,7 +131,8 @@ import { analyticsStore } from '../stores/analytics'
 
 // @ts-ignore
 import type { TrackChoice, TrackResultsConfig, ProgramData } from '@/types/index'
-
+// @ts-ignore
+import { ProgramAidType } from '@/types/programTypes'
 // @ts-ignore
 // import { randomChoice } from '@/utils/helpers'
 
@@ -170,46 +168,34 @@ const updateDetailResult = (id: string | number) => {
   programs.setDetailResult(id, props.trackId)
 }
 
-interface costInfos {
-  prefix: string
-  text: string | undefined
-}
 const getCostInfos = (program: ProgramData) => {
-  let obj: costInfos = {
-    prefix: '',
-    text: ''
-  }
+  let prefix: string = ''
+  let text: string | undefined = ''
   // console.log('TeeResults > onBeforeMount > resultsProgs :', resultsProgs )
+
   switch (program["nature de l'aide"]) {
-    case 'accompagnement':
-      obj.prefix = 'programCosts.costPrefix'
-      obj.text = program["coût de l'accompagnement"]
+    case ProgramAidType.acc:
+      prefix = 'programCosts.costPrefix'
+      text = program["coût de l'accompagnement"]
       break
-    case 'formation':
-      obj.prefix = 'programCosts.costPrefix'
-      obj.text = program["coût de l'accompagnement"]
+    case ProgramAidType.train:
+      prefix = 'programCosts.costPrefix'
+      text = program["coût de l'accompagnement"]
       break
-    case 'financement':
-      obj.prefix = 'programCosts.aidPrefix'
-      obj.text = program['montant du financement']
+    case ProgramAidType.fund:
+      prefix = 'programCosts.aidPrefix'
+      text = program['montant du financement']
       break
-    case 'prêt':
-      obj.prefix = 'programCosts.loan'
-      obj.text = program['montant du prêt']
+    case ProgramAidType.loan:
+      prefix = 'programCosts.loan'
+      text = program['montant du prêt']
       break
   }
-  return obj
-}
+  // Translate prefix
+  prefix = choices.t(prefix)
 
-const getCostInfosPrefix = (program: ProgramData) => {
-  const infos = getCostInfos(program)
-  return infos?.prefix
+  return `${prefix} : ${text}`
 }
-const getCostInfosText = (program: ProgramData) => {
-  const infos = getCostInfos(program)
-  return infos?.text
-}
-
 
 onBeforeMount(() => {
   // console.log('TeeResults > onBeforeMount > resultsProgs :', resultsProgs )

--- a/packages/web/src/components/TeeResults.vue
+++ b/packages/web/src/components/TeeResults.vue
@@ -55,7 +55,7 @@
           <!-- CONTENT -->
           <h2 
             class="fr-card__title tee-program-resume fr-mb-3v"
-            style="font-size: 1.7rem;">
+            style="font-size: 1.7rem; line-height: 2rem;">
             {{ prog.promesse }} 
           </h2>
           <!-- DEBUG -->

--- a/packages/web/src/types/programTypes.ts
+++ b/packages/web/src/types/programTypes.ts
@@ -14,7 +14,7 @@ export enum ProgramAidType {
   loan = 'prêt'
 }
 
-enum ConditionOperators {
+export enum ConditionOperators {
   or = 'or',
   and = 'and',
   is = '==',


### PR DESCRIPTION
Complementary resolution of #165 (itself part of #168)

Result =>

<img width="548" alt="Capture d’écran 2023-10-23 à 16 18 25" src="https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/9ce17bf1-9ed0-47d8-80f5-1b5e2ed109fb">

