### PR TITLE
PR - Corrections on miniature cards

### DIFF
--- a/packages/web/public/css/custom.css
+++ b/packages/web/public/css/custom.css
@@ -169,6 +169,7 @@ WARNING :
 }
 .tee-program-info {
   color: #000091; 
+  font-size: .8rem;
 }
 .tee-program-badge-image {
   text-transform: inherit;

--- a/packages/web/public/css/custom.css
+++ b/packages/web/public/css/custom.css
@@ -171,6 +171,10 @@ WARNING :
   color: #000091; 
   font-size: .8rem;
 }
+.tee-program-info span::before {
+  font-size: .8rem;
+  --icon-size: 1rem;
+}
 .tee-program-badge-image {
   text-transform: inherit;
   color: white;

--- a/packages/web/src/TeeApp.ce.vue
+++ b/packages/web/src/TeeApp.ce.vue
@@ -293,7 +293,7 @@ const getColumnsWidth = computed(() => {
   const colsDebug = 'fr-col-7'
   const colsStart = 'fr-col-12 fr-col-xl-12'
   const colsTracks = 'fr-col fr-col-lg-8 fr-col-xl-6'
-  const colsResults = 'fr-col fr-col-lg-10 fr-col-xl-8'
+  const colsResults = 'fr-col fr-col-lg-8 fr-col-xl-8'
   if (debugBool.value) return colsDebug
   else if (tracks.currentStep === 1) return colsStart
   else if (currentTrack.component === TrackComponents.results) return colsResults

--- a/packages/web/src/TeeApp.ce.vue
+++ b/packages/web/src/TeeApp.ce.vue
@@ -105,7 +105,7 @@
         <!-- TRACKS -->
         <div
           id="tee-app-tracks"
-          :class="`${tracks.currentStep > 1 ? 'fr-tee-add-padding' :''} ${debugBool ? 'fr-col-7' : tracks.currentStep === 1 ? 'fr-col-12 fr-col-xl-12' : 'fr-col fr-col-lg-8 fr-col-xl-6' } ${debugBool ? '' : 'fr-grid-row--center'}`"
+          :class="`${tracks.currentStep > 1 ? 'fr-tee-add-padding' :''} ${getColumnsWidth} ${debugBool ? '' : 'fr-grid-row--center'}`"
           >
           <div
             v-for="(track, index) in tracks.usedTracks"
@@ -212,11 +212,13 @@ import '@gouvfr/dsfr/dist/core/core.main.min.css'               // Le CSS minima
 import jsonDataset from '../public/data/generated/dataset_out.json'
 // console.log('TeeApp > jsonDataset :', jsonDataset)
 
-import { ref, onBeforeMount } from 'vue'
+import { ref, computed, onBeforeMount } from 'vue'
 
 import { tracksStore } from './stores/tracks'
 import { choicesStore } from './stores/choices'
 import { programsStore } from './stores/programs'
+
+import { TrackComponents } from './types'
 
 // @ts-ignore
 import TeeMatomo from './components/TeeMatomo.vue'
@@ -285,6 +287,18 @@ window.stores = { tracks, choices, programs }
 const changeDebug = (ev: any) => {
   debugBool.value = ev
 }
+
+const getColumnsWidth = computed(() => {
+  const currentTrack = tracks.getLastTrack
+  const colsDebug = 'fr-col-7'
+  const colsStart = 'fr-col-12 fr-col-xl-12'
+  const colsTracks = 'fr-col fr-col-lg-8 fr-col-xl-6'
+  const colsResults = 'fr-col fr-col-lg-10 fr-col-xl-8'
+  if (debugBool.value) return colsDebug
+  else if (tracks.currentStep === 1) return colsStart
+  else if (currentTrack.component === TrackComponents.results) return colsResults
+  else return colsTracks
+})
 
 onBeforeMount(() => {
   // console.log('TeeApp > props.seed :', props.seed)

--- a/packages/web/src/assets/custom.css
+++ b/packages/web/src/assets/custom.css
@@ -169,6 +169,7 @@ WARNING :
 }
 .tee-program-info {
   color: #000091; 
+  font-size: .8rem;
 }
 .tee-program-badge-image {
   text-transform: inherit;

--- a/packages/web/src/assets/custom.css
+++ b/packages/web/src/assets/custom.css
@@ -171,6 +171,10 @@ WARNING :
   color: #000091; 
   font-size: .8rem;
 }
+.tee-program-info span::before {
+  font-size: .8rem;
+  --icon-size: 1rem;
+}
 .tee-program-badge-image {
   text-transform: inherit;
   color: white;

--- a/packages/web/src/components/TeeResults.vue
+++ b/packages/web/src/components/TeeResults.vue
@@ -194,6 +194,10 @@ const getCostInfos = (program: ProgramData) => {
   // Translate prefix
   prefix = choices.t(prefix)
 
+  // No splitted amounts (non-breakable spaces in texts like '10 000 €')
+  text = text?.replace(/\s0/g, '\u00A00')
+  text = text?.replace(/\s€/g, '\u00A0€')
+
   return `${prefix} : ${text}`
 }
 

--- a/packages/web/src/stores/tracks.ts
+++ b/packages/web/src/stores/tracks.ts
@@ -7,6 +7,7 @@ import { tracks } from '../questionnaire'
 
 // @ts-ignore
 import type { Translations, UsedTrack } from '@/types/index'
+import { TrackComponents } from '@/types/index'
 
 const allTracks = ref(tracks)
 const seedTrack = ref()
@@ -38,9 +39,13 @@ export const tracksStore = defineStore('tracks', () => {
     }
     return tracksArray
   })
-  const currentStep = computed(() => {
+  const getLastTrack = computed(() => {
     const tracksArray = usedTracks.value.slice(-1)
     const track: UsedTrack = tracksArray[0]
+    return track
+  })
+  const currentStep = computed(() => {
+    const track: UsedTrack = getLastTrack.value
     const stepNumber = track.step
     return stepNumber
   })
@@ -126,19 +131,24 @@ export const tracksStore = defineStore('tracks', () => {
     // console.log('store.tracks > addToUsedTracks > srcTrackId : ', srcTrackId)
     // console.log('store.tracks > addToUsedTracks > newTrackId : ', newTrackId)
 
-    const track = getTrack(srcTrackId)
+    // const srcTrack = getTrack(srcTrackId)
+    // console.log('store.tracks > addToUsedTracks > srcTrack : ', srcTrack)
+    const nextTrack = getTrack(newTrackId)
+    // console.log('store.tracks > addToUsedTracks > nextTrack : ', nextTrack)
 
     removeFurtherUsedTracks(srcTrackId)
 
     // add newTrackId
     const trackInfos: UsedTrack = {
       id: newTrackId,
-      category: track?.category,
+      component: nextTrack?.interface.component || TrackComponents.buttons,
+      category: nextTrack?.category,
       completed: false,
       step: usedTracks.value.length + 1,
       selected: [],
       next: null,
     }
+    console.log('store.tracks > addToUsedTracks > trackInfos : ', trackInfos)
     // @ts-ignore
     usedTracks.value.push(trackInfos)
   }
@@ -195,6 +205,7 @@ export const tracksStore = defineStore('tracks', () => {
     seedTrack,
     usedTracks,
     tracksStepsArray,
+    getLastTrack,
     currentStep,
     setMaxDepth,
     getTrack,

--- a/packages/web/src/types/tracksTypes.ts
+++ b/packages/web/src/types/tracksTypes.ts
@@ -38,10 +38,13 @@ export interface TrackCallout {
   hint?: Translations,
 }
 
-enum TrackComponents {
+export enum TrackComponents {
   cards = 'cards',
   buttons = 'buttons',
-  simpleButtons = 'simpleButtons'
+  simpleButtons = 'simpleButtons',
+  form = 'form',
+  input = 'input',
+  results = 'results'
 }
 export interface TrackInterface {
   component: TrackComponents,
@@ -143,6 +146,7 @@ export interface TracksList {
 
 export interface UsedTrack {
   id: string | any,
+  component: TrackComponents,
   category?: string,
   final?: boolean,
   completed: boolean,


### PR DESCRIPTION
## Issue

Resolution of #187 

## What is done in this PR

- [ ] Inject non-breakable spaces into texts such as `10 000 €` to avoid splitting the text on two lines
- [ ] Miniature cards' width on results page are wider now (cols-10 instead of cols-8)
- [ ] Font size for info text on  miniature cards

Extra : take responsive into account

## Screenshots

<img width="554" alt="Capture d’écran 2023-10-26 à 11 11 12" src="https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/57300aa0-9e01-4321-8c4f-a96ca7cc5c4e">

<img width="947" alt="Capture d’écran 2023-10-26 à 11 11 00" src="https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/57cbf54f-3da9-4b81-b380-beacc4d1820b">

<img width="277" alt="Capture d’écran 2023-10-26 à 11 11 25" src="https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/ed3dd390-60c5-4df1-ba9e-3d93284da48a">

