### PR TITLE
fix: add 'run' on npm `dev-back` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build-json-output": "npm run build-json-output -w packages/data",
     "build-json-output-watch": "npm run build-json-output-watch -w packages/data",
     "dev": "npx concurrently \"npm run build-json-output-watch\" \"npm run dev -w packages/backend\" \"npm run dev -w packages/web\"",
-    "dev-back": "npx concurrently \"npm build-json-output-watch\" \"npm run dev -w packages/backend\"",
+    "dev-back": "npx concurrently \"npm run build-json-output-watch\" \"npm run dev -w packages/backend\"",
     "dev-front": "npx concurrently \"npm run build-json-output-watch\" \"npm run dev -w packages/web\"",
     "test-data": "npm run test -w packages/data"
   },


### PR DESCRIPTION
### What is done

Just fix the `npm run dev-back` command by adding the missing `run` keyword on the following command:  
`npx concurrently "npm build-json-output-watch" "npm run dev -w packages/backend"`
replace by
`npx concurrently "npm run build-json-output-watch" "npm run dev -w packages/backend"`