### PR TITLE
perf: quick win for filtering programs with publicodes

### DIFF
--- a/packages/backend/src/domain/eligibility.ts
+++ b/packages/backend/src/domain/eligibility.ts
@@ -33,22 +33,22 @@ export const filterPrograms = (
   programs: ProgramData[],
   inputData: InputData
 ): Result<ProgramData[], Error> => {
-  const eligibilityResults = programs.map((p) => evaluateRule(p.publicodes, inputData))
+  let filteredPrograms: ProgramData[] = []
 
-  for (const e of eligibilityResults) {
+  for (const p of programs) {
+    const e = evaluateRule(p.publicodes, inputData)
+
     if (e.isErr) {
       return Result.err(e.error)
     }
-  }
-
-  const filteredPrograms = programs.filter((p) => {
-    const e = evaluateRule(p.publicodes, inputData)
 
     const isPositive = e.isOk && e.value
     const isUndefined = e.isOk && typeof e.value === 'undefined'
 
-    return isPositive || isUndefined
-  })
+    if (isPositive || isUndefined) {
+      filteredPrograms.push(p)
+    }
+  }
 
   return Result.ok(filteredPrograms)
 }

--- a/packages/backend/src/domain/eligibility.ts
+++ b/packages/backend/src/domain/eligibility.ts
@@ -35,15 +35,15 @@ export const filterPrograms = (
 ): Result<ProgramData[], Error> => {
   let filteredPrograms: ProgramData[] = []
 
-  for (const p of programs) {
-    const e = evaluateRule(p.publicodes, inputData)
+  for (const program of programs) {
+    const evaluation = evaluateRule(program.publicodes, inputData)
 
-    if (e.isErr) {
-      return Result.err(e.error)
+    if (evaluation.isErr) {
+      return Result.err(evaluation.error)
     }
 
-    if (shouldKeepProgram(e)) {
-      filteredPrograms.push(p)
+    if (shouldKeepProgram(evaluation)) {
+      filteredPrograms.push(program)
     }
   }
 

--- a/packages/backend/src/domain/eligibility.ts
+++ b/packages/backend/src/domain/eligibility.ts
@@ -42,15 +42,19 @@ export const filterPrograms = (
       return Result.err(e.error)
     }
 
-    const isPositive = e.isOk && e.value
-    const isUndefined = e.isOk && typeof e.value === 'undefined'
-
-    if (isPositive || isUndefined) {
+    if (shouldKeepProgram(e)) {
       filteredPrograms.push(p)
     }
   }
 
   return Result.ok(filteredPrograms)
+}
+
+const shouldKeepProgram = (evaluation: Result<boolean | undefined, Error>): boolean => {
+  const isPositive = evaluation.isOk && evaluation.value
+  const isUndefined = evaluation.isOk && typeof evaluation.value === 'undefined'
+
+  return isPositive || isUndefined
 }
 
 /** Evaluates given program specific rules and user specific input data, if


### PR DESCRIPTION
For no other reason than it was easier to write, the `publicodes` chunks were evaluated twice for filtering. 

As performance is a concern, this PR proposes a quick win, by evaluating the code only once. 

The modified `filterPrograms` function is unit tested. 

Hint : easier to review in [split mode](https://github.com/betagouv/transition-ecologique-entreprises-widget/pull/221/files?diff=split&w=0) 

Ref ticket : #164 