### PR TITLE
feat(redirection): ajout des redirections

### DIFF
--- a/packages/web/src/router/index.ts
+++ b/packages/web/src/router/index.ts
@@ -15,6 +15,8 @@ import TeeProgramPage from '../pages/TeeProgramPage.vue'
 import TeeLegalPage from '../pages/TeeLegalPage.vue'
 import TeeAccessibilityPage from '../pages/TeeAccessibilityPage.vue'
 import TeePersonalDataPage from '../pages/TeePersonalDataPage.vue'
+import { RouteName } from '@/types/routeType'
+import { redirections } from '@/router/redirection'
 
 
 const resetTrackStore = async (to: any, from: any, next: any) => {
@@ -56,12 +58,12 @@ export const router = createRouter({
     return { top: 0 }
   },
   routes: [
-    { 
+    {
       path: '/',
-      name: 'homepage', 
+      name: RouteName.Homepage,
       component: TeeHomePage
     },
-    { 
+    {
       path: '/questionnaire',
       component: TeeQuestionnairePage,
       beforeEnter: [
@@ -72,7 +74,7 @@ export const router = createRouter({
       children: [
         {
           path: '',
-          name: 'questionnaire', 
+          name: 'questionnaire',
           // component: TeeQuestionnairePage,
           component: WidgetApp,
           // component: TeeProgramPage,
@@ -81,16 +83,16 @@ export const router = createRouter({
             disableWidget: true
           }
         },
-        { 
+        {
           path: ':programId',
-          name: 'questionnaire-detail', 
+          name: 'questionnaire-detail',
           // component: TeeQuestionnairePage,
           component: TeeProgramPage,
           // component: TeeProgramPage,
         },
       ]
     },
-    { 
+    {
       path: '/annuaire',
       component: TeeCatalogPage,
       beforeEnter: [
@@ -101,40 +103,41 @@ export const router = createRouter({
       children: [
         {
           path: '',
-          name: 'catalog', 
+          name: 'catalog',
           component: WidgetApp,
           props: {
             seed: 'track_results',
             disableWidget: true
           }
         },
-        { 
+        {
           path: ':programId',
-          name: 'catalogue-detail', 
+          name: 'catalogue-detail',
           component: TeeProgramPage,
         },
       ]
     },
-    { 
-      path: '/mentions-legales', 
+    {
+      path: '/mentions-legales',
       name: 'legal',
       component: TeeLegalPage
     },
-    { 
-      path: '/accessibilite', 
+    {
+      path: '/accessibilite',
       name: 'accessibility',
       component: TeeAccessibilityPage
     },
-    { 
-      path: '/donnees-personnelles', 
+    {
+      path: '/donnees-personnelles',
       name: 'personal-data',
       component: TeePersonalDataPage
     },
     {
       path: '/*',
-      name: '404', 
+      name: '404',
       component: TeeHomePage,
-    }
+    },
+    ...redirections,
     // { path: '/track/:trackId', component: TeeTrack },
     // { path: '/program/:programId', component: TeeProgramDetail },
   ]

--- a/packages/web/src/router/redirection.ts
+++ b/packages/web/src/router/redirection.ts
@@ -1,0 +1,17 @@
+import type { RouteRecordRaw } from 'vue-router'
+import { RouteName } from '@/types/routeType'
+
+export const redirections: RouteRecordRaw[] = [
+  {
+    path: "/comprendre",
+    redirect: to => {
+      return { name: RouteName.Homepage }
+    },
+  },
+  {
+    path: "/recherche:afterSearch(.*)",
+    redirect: to => {
+      return { name: RouteName.Homepage, query: null }
+    },
+  }
+]

--- a/packages/web/src/types/routeType.ts
+++ b/packages/web/src/types/routeType.ts
@@ -1,0 +1,3 @@
+export enum RouteName {
+  Homepage = 'homepage',
+}


### PR DESCRIPTION
### Besoin
Ajout des redirections sur la homepage des anciennes url de l'applicatif symfony
#208 

## Ce qui a été fait
- Un fichier dédié `redirection.ts` pour la gestion des redirections dans le router a été ajouter dans le dossier `src/router/`.  
Il contient l'ensemble des routes à rediriger.

- Un enum des noms route a été ajouté (`src/types/routeType.ts`) car il me semble plus pertinent de fonctionner avec des noms de routes (`name`) plutôt qu'avec le `path`. Ceci permet de pouvoir changer les url sans changer de partout dans le code. Et avec les enums ont peux avoir une liste accessible des noms de routes