### PR TITLE
fix: reduce margins and padding around CTA in home page

### DIFF
--- a/packages/web/src/components/home/TeeCta.vue
+++ b/packages/web/src/components/home/TeeCta.vue
@@ -5,7 +5,7 @@
     <div 
       class="fr-col fr-col-md-8 fr-col-lg-8 tee-track-has-image-right">
       <div class="fr-grid-row fr-grid-row--gutters fr-p-5v fr-p-sm-8v fr-p-md-20v">
-        <div class="fr-col-12 fr-mb-10v fr-mx-0 fr-px-2v">
+        <div class="fr-col-12 fr-mb-4v fr-mx-0 fr-px-2v">
           <div class="fr-px-2v" style="background-color: transparent;">
             <div class="tee-track-callout fr-grid-row fr-grid-row--gutters">
               <div class="fr-col">

--- a/packages/web/src/pages/TeeHomePage.vue
+++ b/packages/web/src/pages/TeeHomePage.vue
@@ -4,7 +4,7 @@
     class="fr-container--fluid"
     style="background-color: #E8EDFF;">
     <div
-      class="fr-container fr-py-20v">
+      class="fr-container fr-py-2v">
       <TeeCta/>
     </div>
   </div>


### PR DESCRIPTION
solves #269 

## Avant

![Capture d’écran 2023-11-16 à 15 06 48](https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/018537bd-aa9d-40f6-ae4b-c90526bf54e4)

## Après

![Capture d’écran 2023-11-16 à 15 06 29](https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/1bb01c07-644f-40b1-9e5e-ec47688a252d)
