### PR TITLE
fix: adjust UI and UX on first track + css addons

### DIFF
--- a/packages/web/public/css/custom.css
+++ b/packages/web/public/css/custom.css
@@ -7,6 +7,9 @@ WARNING :
 */
 
 /* CUSTOM STYLES - OVERIDES DSFR */
+.fr-justify-center {
+  justify-content: center;
+}
 .fr-text-center {
   text-align: center;
 }

--- a/packages/web/src/WidgetApp.ce.vue
+++ b/packages/web/src/WidgetApp.ce.vue
@@ -79,7 +79,7 @@
         <!-- SIDEBAR MENU (FIL D'ARIANE)-->
         <div
           v-if="needSidebar && tracks.currentStep > 1"
-          class="fr-tee-add-padding fr-mt-4v fr-col-3 fr-col-md-4 fr-col-lg-4 fr-col-xl-2 fr-col-offset-xl-1 fr-col-sm-hide"
+          class="fr-tee-add-padding fr-mt-4v fr-col-3 fr-col-md-4 fr-col-lg-4 fr-col-xl-2 fr-col-sm-hide"
           style="height: 100%;">
           <TeeSidebar
             :used-tracks="tracks.usedTracks"

--- a/packages/web/src/WidgetApp.ce.vue
+++ b/packages/web/src/WidgetApp.ce.vue
@@ -74,12 +74,12 @@
       <!-- TRACKS INTERFACES -->
       <div
         ref="tee-app-tracks"
-        class="fr-grid-row fr-grid-row-gutters fr-p-0">
+        class="fr-grid-row fr-grid-row-gutters fr-p-0 fr-justify-center">
 
         <!-- SIDEBAR MENU (FIL D'ARIANE)-->
         <div
-          v-if="needSidebar"
-          class="fr-tee-add-padding fr-col-3 fr-col-md-4 fr-col-lg-4 fr-col-xl-2 fr-col-offset-xl-1 fr-col-sm-hide"
+          v-if="needSidebar && tracks.currentStep > 1"
+          class="fr-tee-add-padding fr-mt-4v fr-col-3 fr-col-md-4 fr-col-lg-4 fr-col-xl-2 fr-col-offset-xl-1 fr-col-sm-hide"
           style="height: 100%;">
           <TeeSidebar
             :used-tracks="tracks.usedTracks"
@@ -90,7 +90,7 @@
         <!-- TRACKS -->
         <div
           id="tee-app-tracks"
-          :class="`${tracks.currentStep > 1 ? 'fr-tee-add-padding' :''} ${getColumnsWidth} ${debugBool ? '' : 'fr-grid-row--center'}`"
+          :class="`${tracks.currentStep > 1 ? 'fr-tee-add-padding' : ''} ${getColumnsWidth} ${debugBool ? '' : 'fr-grid-row--center'}`"
           >
           <div
             v-for="(track, index) in tracks.usedTracks"

--- a/packages/web/src/assets/custom.css
+++ b/packages/web/src/assets/custom.css
@@ -7,6 +7,9 @@ WARNING :
 */
 
 /* CUSTOM STYLES - OVERIDES DSFR */
+.fr-justify-center {
+  justify-content: center;
+}
 .fr-text-center {
   text-align: center;
 }

--- a/packages/web/src/components/TeeTrack.vue
+++ b/packages/web/src/components/TeeTrack.vue
@@ -106,7 +106,7 @@
                   <!-- CALLOUT DESCRIPTION -->
                   <p
                     v-if="track.callout.description"
-                    class="fr-callout__text tee-track-callout-description"
+                    class="fr-callout__text tee-track-callout-description fr-mb-2v"
                     :style="`${track.callout.descriptionStyle || ''}`">
                     {{ track.callout.description[choices.lang]}}
                   </p>

--- a/packages/web/src/pages/TeeQuestionnairePage.vue
+++ b/packages/web/src/pages/TeeQuestionnairePage.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- MAIN APP COMPONENT  -->
   <div
-    class="fr-container--fluid fr-px-2v fr-pb-20v fr-mt-10v fr-mb-20v"
+    class="fr-container--fluid fr-px-2v fr-pb-20v fr-mt-0 fr-mb-20v"
     style="min-height: 800px">
     <router-view/>
   </div>


### PR DESCRIPTION
solves #200 (finishes the job)

## What was done

- Coller le bloc jaune (_alias_ le "callout") au _header_ (_alias_ la "navbar")
- Ajouter un  peu de marge en haut de la _sidebar_ de gauche (_alias_ le "fil d'Ariane"), pour éviter que celle-ci soit trop collée à la navbar
- Cacher le fil d'Ariane sur la première question
- Quelques modifs de css pour tenter de compacter un peu le texte contenu dans le callout.

## Avant

![Capture d’écran 2023-11-20 à 12 17 59](https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/ac0bdf88-0cb4-42d9-9fe7-e9906bb6991d)

---

## Après

![Capture d’écran 2023-11-20 à 12 16 47](https://github.com/betagouv/transition-ecologique-entreprises-widget/assets/21986727/2d51c730-067e-401d-9e57-fffb59474610)
