### PR TITLE
fix: display program objective title depending of program type

### DIFF
--- a/packages/web/src/WidgetApp.ce.vue
+++ b/packages/web/src/WidgetApp.ce.vue
@@ -226,7 +226,7 @@ import TeeTrack from './components/TeeTrack.vue'
 // @ts-ignore
 import TeeSidebar from './components/TeeSidebar.vue'
 // @ts-ignore
-import TeeProgramDetail from './components/TeeProgramDetail.vue'
+import TeeProgramDetail from './components/program/TeeProgramDetail.vue'
 // @ts-ignore
 import TeeCredits from './components/TeeCredits.vue'
 import { TrackId } from '@/types'

--- a/packages/web/src/components/program/ProgramObjective.vue
+++ b/packages/web/src/components/program/ProgramObjective.vue
@@ -1,0 +1,49 @@
+<template>
+  <div
+    class='fr-mb-18v'>
+    <h3>
+      {{ getProgramObjectiveTitle() }}
+    </h3>
+    <div class='fr-tee-description-list'>
+      <p
+        v-for='(paragraph, idx) in program.objectifs'
+        :key='`description-paragraph-${idx}`'
+        class='fr-mb-6v'
+      >
+        <span class='fr-tee-description-paragraph-marker'>
+          {{ idx + 1 }} |
+        </span>
+        <span class='fr-tee-description-paragraph-content'>
+          {{ paragraph }}
+        </span>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang='ts'>
+
+import { choicesStore } from '@tee/web/src/stores/choices'
+import type { ProgramData } from '@/types'
+import { ProgramAidType } from '@/types'
+
+interface Props {
+  program: ProgramData,
+}
+
+const props = defineProps<Props>()
+
+const getProgramObjectiveTitle = () => {
+  switch (props.program['nature de l\'aide']) {
+    case ProgramAidType.acc:
+    case ProgramAidType.train:
+    case ProgramAidType.loan:
+    case ProgramAidType.tax:
+      return choices.t('program.programObjective.title.base')
+    case ProgramAidType.fund:
+      return choices.t('program.programObjective.title.second')
+  }
+}
+
+const choices = choicesStore()
+</script>

--- a/packages/web/src/components/program/TeeProgramDetail.vue
+++ b/packages/web/src/components/program/TeeProgramDetail.vue
@@ -60,29 +60,7 @@
           @click="toggleShowForm"
           ref="modalOrigin"/> -->
 
-        <!-- PROGRAM DESCRIPTION -->
-        <div
-          class="fr-mb-18v">
-          <h3>
-            {{ choices.t('program.programDescription') }}
-          </h3>
-          <div class="fr-tee-description-list">
-            <p
-              v-for="(paragraph, idx) in program.objectifs"
-              :key="`description-paragraph-${idx}`"
-              class="fr-mb-6v">
-              <span
-                class="fr-tee-description-paragraph-marker">
-                {{ idx + 1 }} |
-              </span>
-              <span
-                class="fr-tee-description-paragraph-content">
-                {{ paragraph }}
-              </span>
-            </p>
-          </div>
-        </div>
-
+        <ProgramObjective :program='program'></ProgramObjective>
       </div>
 
     </div>
@@ -289,18 +267,19 @@
 import { ref, onBeforeMount } from 'vue'
 
 // @ts-ignore
-import TeeTile from './TeeTile.vue'
+import TeeTile from '../TeeTile.vue'
 // @ts-ignore
-import TeeForm from './TeeForm.vue'
+import TeeForm from '../TeeForm.vue'
 
-import { choicesStore } from '../stores/choices'
-import { tracksStore } from '../stores/tracks'
-import { programsStore } from '../stores/programs'
-import { navigationStore } from '../stores/navigation'
-import { analyticsStore } from '../stores/analytics'
+import { choicesStore } from '../../stores/choices'
+import { tracksStore } from '../../stores/tracks'
+import { programsStore } from '../../stores/programs'
+import { navigationStore } from '../../stores/navigation'
+import { analyticsStore } from '../../stores/analytics'
 
-import { scrollToId } from '../utils/helpers'
+import { scrollToId } from '../../utils/helpers'
 import type { TrackId } from '@/types'
+import ProgramObjective from '@/components/program/ProgramObjective.vue'
 
 const choices = choicesStore()
 const tracks = tracksStore()
@@ -329,7 +308,7 @@ const resetDetailResult = async () => {
   programs.resetDetailResult()
   nav.setCurrentDetailId('', props.disableWidget)
   nav.updateUrl(props.disableWidget)
-  
+
   scrollToId(`${props.programId}`)
 }
 const toggleShowForm = () => {

--- a/packages/web/src/pages/TeeProgramPage.vue
+++ b/packages/web/src/pages/TeeProgramPage.vue
@@ -28,7 +28,7 @@ import { useRouter, useRoute } from 'vue-router'
 // @ts-ignore
 import WidgetApp from '@/WidgetApp.ce.vue'
 // @ts-ignore
-import TeeProgramDetail from '@/components/TeeProgramDetail.vue'
+import TeeProgramDetail from '@/components/program/TeeProgramDetail.vue'
 import { TrackId } from '@/types'
 
 const router = useRouter()

--- a/packages/web/src/translations/fr.ts
+++ b/packages/web/src/translations/fr.ts
@@ -49,7 +49,12 @@ export const frDict = {
   },
   program: {
     programResume: 'Le dispositif en deux mots',
-    programDescription: 'Au programme :',
+    programObjective: {
+      title: {
+        base: 'Au programme :',
+        second: 'Les étapes de votre demande d’aide :'
+      }
+    },
     programProviders: 'Contact',
     programType: "Nature de l'aide",
     programDuration: 'Prestation',


### PR DESCRIPTION
- #295

### Ce qui est fait

Un nouveau component permet la gestion et l'affichage des objectifs du programme.

Le titre est affiché en fonction de la nature de l'aide du programme.

```ts
switch (props.program['nature de l\'aide']) {
    case ProgramAidType.acc:
    case ProgramAidType.train:
    case ProgramAidType.loan:
    case ProgramAidType.tax:
      return choices.t('program.programObjective.title.base')
    case ProgramAidType.fund:
      return choices.t('program.programObjective.title.second')
  }
```