### PR TITLE
fix: replace lookahead regex to simpler regex to work on safari and IE

### DIFF
--- a/packages/web/src/utils/helpers.ts
+++ b/packages/web/src/utils/helpers.ts
@@ -370,6 +370,6 @@ export const scrollToId = (
 // TEXT HELPERS
 
 export const consolidateAmounts = (str: string | undefined) => {
-  const regex = /(?<=\d)\s(?=\d)|(?<=\d)\s(?=\D)/g
-  return str?.replace(regex, '\u00a0')
+  const regex = /(\d+)\s*([a-zA-Z])?/g
+  return str?.replace(regex, '$1\u00a0$2')
 }


### PR DESCRIPTION
### Issue
- #310 

Le pb vient d'une regex utilisant les lookbehind pour le formatage d'un texte avec un valeur de type monétaire  ou pourcentage.

https://javascript.info/regexp-lookahead-lookbehind#lookbehind
https://caniuse.com/js-regexp-lookbehind

### Ce qui est fait
La regex utilisant les lookbehind est replacé par une regex plus simple et tout aussi fonctionnelle mais accepter les navigateur tel que safari et IE