### PR TITLE
fix: bug to display form title on "formation" program type

### DIFF
--- a/packages/web/src/translations/fr.ts
+++ b/packages/web/src/translations/fr.ts
@@ -110,6 +110,11 @@ export const frDict = {
       the: "l'",
       this: 'cet',
       of: "de l'"
-    }
+    },
+    formation: {
+      the: 'la',
+      this: 'cette',
+      of: 'de la'
+    },
   }
 }


### PR DESCRIPTION
- fix #375 
add missing translation to display form title on "formation" program type