### PR TITLE
feat: on contact form, siret field is now required

### DIFF
--- a/packages/backend/src/contact/domain/types.ts
+++ b/packages/backend/src/contact/domain/types.ts
@@ -4,7 +4,7 @@ export interface ContactInfoBodyAttributes {
   NOM: string
   PRENOM: string
   TEL: string
-  SIRET?: string
+  SIRET: string
   OPT_IN: boolean
   FORM_NEEDS?: string
   PROJECT_NEEDS?: string

--- a/packages/web/src/questionnaire/trackResults.ts
+++ b/packages/web/src/questionnaire/trackResults.ts
@@ -173,7 +173,7 @@ export const results: Track = {
         id: 'siret',
         label: { fr: 'SIRET de votre entreprise' },
         hint: { fr: '385 290 309 00454' },
-        required: false,
+        required: true,
         type: FormFieldTypes.Text,
         preFillFrom: {
           id: 'siret',


### PR DESCRIPTION
- cf #460 

### Ce qui est fait
Le siret (re)devient obligatoire sur la formulaire (front) et sur le typage (back)

Attention, il n'y pas pas encore de validation sur les différents champs du formulaire