### PR TITLE
refactor(establishment): `get /establishments/{siret}`

### DIFF
--- a/packages/backend/src/establishment/controller/establishmentController.ts
+++ b/packages/backend/src/establishment/controller/establishmentController.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Route, SuccessResponse, TsoaResponse, Res, Example } from 'tsoa'
+import { Controller, Route, SuccessResponse, TsoaResponse, Res, Example, Get, Path } from 'tsoa'
 import { fetchEtablissement } from '../application/fetchEtablissement'
 import { EstablishmentNotFoundError, Etablissement } from '../domain/types'
 import { ErrorJSON, ValidateErrorJSON } from '../../common/controller/jsonError'
@@ -7,12 +7,10 @@ interface EstablishmentNotFoundErrorJSON {
   message: 'Establishment not found'
 }
 
-interface SiretBody {
-  /**
-   * @pattern ^\d{14}$ SIRET should be made of 14 digits
-   */
-  siret: string
-}
+/**
+ * @pattern ^\d{14}$ SIRET should be made of 14 digits
+ */
+export type Siret = string
 
 const exampleEtablissement = {
   siren: '830141321',
@@ -112,7 +110,7 @@ const exampleEtablissement = {
 }
 
 @SuccessResponse('200', 'OK')
-@Route('insee')
+@Route('establishments')
 export class SireneController extends Controller {
   /**
    * Retrieves information of an Establishment ("Établissement").
@@ -124,16 +122,14 @@ export class SireneController extends Controller {
    */
 
   @Example<Etablissement>(exampleEtablissement)
-  @Post('get_by_siret')
+  @Get('{siret}')
   public async health(
-    @Body() requestBody: SiretBody,
+    @Path() siret: Siret,
     @Res() requestFailedResponse: TsoaResponse<500, ErrorJSON>,
     @Res() _validationFailedResponse: TsoaResponse<422, ValidateErrorJSON>,
     @Res() notFoundResponse: TsoaResponse<404, EstablishmentNotFoundErrorJSON>
   ): Promise<Etablissement> {
-    const requestedSiret = requestBody.siret
-
-    const etablissementResult = await fetchEtablissement(requestedSiret)
+    const etablissementResult = await fetchEtablissement(siret)
 
     if (etablissementResult.isErr) {
       const err = etablissementResult.error

--- a/packages/web/src/questionnaire/trackStructureSiret.ts
+++ b/packages/web/src/questionnaire/trackStructureSiret.ts
@@ -72,14 +72,13 @@ export const siret: Track = {
           help: 'Get entreprise data from its SIRET number',
           helpDocumentation: 'https://tee-backend.osc-fr1.scalingo.io/api/docs',
           action: CallbackActions.RequestAPI,
-          url: '/api/insee/get_by_siret',
-          // url: 'http://localhost:8001/api/insee/get_by_siret',
-          method: CallbackMethods.Post,
+          url: '/api/establishments/{siret}',
+          method: CallbackMethods.Get,
           headers: {
             accept: 'application/json',
             'Content-Type': 'application/json'
           },
-          dataBody: { siret: '' },
+          dataPath: { siret: '' },
           dataStructure: { ...dataTarget },
           dataMapping: [
             {
@@ -202,13 +201,6 @@ export const siret: Track = {
               dataField: 'codePostal',
               onlyRemap: true
             }
-            // {
-            //   from: DataMappingFrom.RawData,
-            //   id: 'size',
-            //   path: 'etablissement.uniteLegale.categorieEntreprise',
-            //   dataField: 'structure_sizes',
-            //   onlyRemap: true
-            // },
           ],
           inputCleaning: [
             {

--- a/packages/web/src/types/formTypes.ts
+++ b/packages/web/src/types/formTypes.ts
@@ -47,6 +47,7 @@ export interface FormCallback {
   headers: HeadersInit
   method: CallbackMethods
   dataBody?: object | object[]
+  dataPath?: Record<string, string>
   dataStructure: object | object[]
   dataMapping: FormCallbackDataMapping[]
   inputCleaning?: Cleaner[] | CleanerReplaceAll[] | CleanerFromJson[] | CleanerFromDict[] | CleanerDefaultIfNull[]

--- a/packages/web/src/utils/requests.ts
+++ b/packages/web/src/utils/requests.ts
@@ -40,7 +40,7 @@ const replacePlaceholders = (url: string, dataPath?: Record<string, string>): st
 
   for (const placeholderName in dataPath) {
     const placeholderData = dataPath[placeholderName]
-    url = replacePlaceholder(placeholderName, placeholderData, url)
+    url = replacePlaceholder(url, placeholderName, placeholderData)
   }
 
   return url

--- a/packages/web/src/utils/requests.ts
+++ b/packages/web/src/utils/requests.ts
@@ -46,10 +46,8 @@ const replacePlaceholders = (url: string, dataPath?: Record<string, string>): st
   return url
 }
 
-const replacePlaceholder = (url: string, placeholderName: string, placeholderData: string | undefined): string => {
-  if (placeholderData) {
-    url = url.replace('{' + placeholderName + '}', placeholderData)
-  }
+const replacePlaceholder = (url: string, placeholderName: string, placeholderData: string): string => {
+  url = url.replace('{' + placeholderName + '}', placeholderData)
   return url
 }
 

--- a/packages/web/src/utils/requests.ts
+++ b/packages/web/src/utils/requests.ts
@@ -47,8 +47,7 @@ const replacePlaceholders = (url: string, dataPath?: Record<string, string>): st
 }
 
 const replacePlaceholder = (url: string, placeholderName: string, placeholderData: string): string => {
-  url = url.replace('{' + placeholderName + '}', placeholderData)
-  return url
+  return url.replace('{' + placeholderName + '}', placeholderData)
 }
 
 export const sendRequest = async (

--- a/packages/web/src/utils/requests.ts
+++ b/packages/web/src/utils/requests.ts
@@ -37,10 +37,13 @@ const replacePlaceholders = (url: string, dataPath?: Record<string, string>): st
   if (!dataPath) {
     return url
   }
-  const placeholderRegexp = new RegExp('{([^{}]+)}', 'g')
-  const matches = [...url.matchAll(placeholderRegexp)]
-  const placeholders = matches.map((placeholder) => /* capture group */ placeholder[1])
-  return placeholders.reduce((accu: string, placeholder: string) => replacePlaceholder(accu, placeholder, dataPath?.[placeholder]), url)
+
+  for (const placeholderName in dataPath) {
+    const placeholderData = dataPath[placeholderName]
+    url = replacePlaceholder(placeholderName, placeholderData, url)
+  }
+
+  return url
 }
 
 const replacePlaceholder = (url: string, placeholderName: string, placeholderData: string | undefined): string => {


### PR DESCRIPTION
Annule et remplace la PR #96 

> ### Context
> 
> The Sirene API is currently served as a "POST /api/insee/get_by_siret" endpoint which requires the data to be provided in the request body.
> ### Suggestion
> 
> I would suggest two changes :
> 
>  - First, the API should be exposed as a GET endpoint (as the name suggests). The siret could then be provided as a path parameter instead, e.g. "/api/insee/get_by_siret/83014132100034"
>   - I suggest to change the API endpoint name, because of following shortcomings with the current name :
>         "insee" should not be part of the name, as the data provider is actually none of the business of the frontend. It may change in the future (e.g. switching to API entreprise), and a change of routes should not be required in this case.
>         "get_by_siret" > if the verb changes to GET, then it should not be repeated in the endpoint. Also, REST API good practices is to [name the endpoint after the resource collection that is fetched as a noun (see 2.1)](https://restfulapi.net/resource-naming/), and not with a verb. In addition, current naming does not convey what is returned by the API call.
>         Therefore, I suggest followin naming : "/api/etablissements/{siret}"

(Seule différence avec ce que j'avais suggéré : `establishments` au lieu of `etablissements`).

### Implémentation

J'ai dû, en sus, implémenter la gestion des paramètres dans l'url (ici le siret) pour pouvoir faire appel à ce nouvel endpoint via le front malgré le mécanisme de callback générique.

J'ai fait ça via des placeholders : si on fournit une URL de la forme `/etablissements/{siret}` ainsi qu'un objet `{siret: "0123"}` à la propriété `DataPath` du callback (nouvelle propriété, calquée sur `DataBody`), alors `{siret}` est remplacé par `0123` pour l'appel d'API.

