### PR TITLE
fix: headers CSP for matomo

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -56,12 +56,12 @@ const viteServer: ServerOptions = {
       "base-uri 'self';" +
       "form-action 'self';" +
       "script-src 'self';" +
-      "script-src-elem 'self';" +
+      "script-src-elem 'self' 'sha256-PNy1JqjViuKB4TRVA9dGD8G/yia50xi0NgGkH2cMqkI=' https://stats.beta.gouv.fr;" +
       "style-src 'self' 'unsafe-inline';" +
       "font-src 'self';" +
       "img-src 'self' data:;" +
       "object-src 'self';" +
-      "connect-src 'self' https://place-des-entreprises.beta.gouv.fr;" +
+      "connect-src 'self' https://place-des-entreprises.beta.gouv.fr https://stats.beta.gouv.fr;" +
       "frame-src 'self' https://place-des-entreprises.beta.gouv.fr;" +
       "frame-ancestors 'self' https://place-des-entreprises.beta.gouv.fr;",
     'X-Frame-Options': 'ALLOW-FROM https://place-des-entreprises.beta.gouv.fr',


### PR DESCRIPTION
hotfix pour les envoies des event Matomo. Depuis que les headers CSP ont été mis en prod les envoie des stats matomo ne sont plus fait car le nom et le script matomo n'est pas accepté par la configuration des CSP