### PR TITLE
refactor: Publicodes s'initialise au lancement du serveur d'API

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -23,7 +23,7 @@ app.use('/api/docs', swaggerUi.serve, async (_req: Request, res: Response) => {
   return res.send(swaggerUi.generateHTML(await import('../generated/swagger.json')))
 })
 
-app.set('programService', new ProgramService())
+ProgramService.init()
 
 RegisterRoutes(app)
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -5,6 +5,7 @@ import { ValidateError } from 'tsoa'
 import cors from 'cors'
 import Sentry from './plugin/sentry'
 import * as dotenv from 'dotenv'
+import ProgramService from './program/application/programService'
 
 dotenv.config()
 
@@ -21,6 +22,8 @@ app.use(cors())
 app.use('/api/docs', swaggerUi.serve, async (_req: Request, res: Response) => {
   return res.send(swaggerUi.generateHTML(await import('../generated/swagger.json')))
 })
+
+app.set('programService', new ProgramService())
 
 RegisterRoutes(app)
 

--- a/packages/backend/src/program/application/programService.ts
+++ b/packages/backend/src/program/application/programService.ts
@@ -6,13 +6,14 @@ import { QuestionnaireData } from '../domain/types'
 
 import ProgramsJson from '../infrastructure/programsJson'
 import { currentDateService } from '../infrastructure/currentDate'
-import { publicodesService } from '../infrastructure/publicodes'
+import { PublicodesService } from '../infrastructure/publicodesService'
 
 export default class ProgramService {
   private _program: ProgramFeatures
 
   constructor() {
-    this._program = new ProgramFeatures(ProgramsJson.getInstance(), currentDateService, publicodesService)
+    const programsService = ProgramsJson.getInstance()
+    this._program = new ProgramFeatures(programsService, currentDateService, new PublicodesService(programsService.getAll()))
   }
 
   public getById(id: string): Program | undefined {

--- a/packages/backend/src/program/application/programService.ts
+++ b/packages/backend/src/program/application/programService.ts
@@ -11,9 +11,13 @@ import { PublicodesService } from '../infrastructure/publicodesService'
 export default class ProgramService {
   private _program: ProgramFeatures
 
-  constructor() {
+  public static init(): void {
+    PublicodesService.init(ProgramsJson.getInstance().getAll())
+  }
+
+  public constructor() {
     const programsService = ProgramsJson.getInstance()
-    this._program = new ProgramFeatures(programsService, currentDateService, new PublicodesService(programsService.getAll()))
+    this._program = new ProgramFeatures(programsService, currentDateService, PublicodesService.getInstance())
   }
 
   public getById(id: string): Program | undefined {

--- a/packages/backend/src/program/controller/programsController.ts
+++ b/packages/backend/src/program/controller/programsController.ts
@@ -1,5 +1,4 @@
-import { Controller, Get, Path, Queries, Res, Request, Route, SuccessResponse, TsoaResponse } from 'tsoa'
-import { Request as ExpressRequest } from 'express'
+import { Controller, Get, Path, Queries, Res, Route, SuccessResponse, TsoaResponse } from 'tsoa'
 import ProgramService from '../application/programService'
 import { OpenAPISafeProgram } from './types'
 import { ErrorJSON } from '../../common/controller/jsonError'
@@ -19,10 +18,9 @@ export class ProgramsController extends Controller {
   @Get()
   public get(
     @Queries() questionnaireData: QuestionnaireData,
-    @Res() requestFailedResponse: TsoaResponse<500, ErrorJSON>,
-    @Request() request: ExpressRequest
+    @Res() requestFailedResponse: TsoaResponse<500, ErrorJSON>
   ): OpenAPISafeProgram[] | void {
-    const programService = request.app.get('programService') as ProgramService
+    const programService = new ProgramService()
     this.setStatus(200)
 
     const programsResult = programService.getFilteredPrograms(questionnaireData)

--- a/packages/backend/src/program/controller/programsController.ts
+++ b/packages/backend/src/program/controller/programsController.ts
@@ -22,7 +22,7 @@ export class ProgramsController extends Controller {
     @Res() requestFailedResponse: TsoaResponse<500, ErrorJSON>,
     @Request() request: ExpressRequest
   ): OpenAPISafeProgram[] | void {
-    const programService = request.app.get('programService')
+    const programService = request.app.get('programService') as ProgramService
     this.setStatus(200)
 
     const programsResult = programService.getFilteredPrograms(questionnaireData)

--- a/packages/backend/src/program/controller/programsController.ts
+++ b/packages/backend/src/program/controller/programsController.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Path, Queries, Res, Route, SuccessResponse, TsoaResponse } from 'tsoa'
+import { Controller, Get, Path, Queries, Res, Request, Route, SuccessResponse, TsoaResponse } from 'tsoa'
+import { Request as ExpressRequest } from 'express'
 import ProgramService from '../application/programService'
 import { OpenAPISafeProgram } from './types'
 import { ErrorJSON } from '../../common/controller/jsonError'
@@ -18,11 +19,13 @@ export class ProgramsController extends Controller {
   @Get()
   public get(
     @Queries() questionnaireData: QuestionnaireData,
-    @Res() requestFailedResponse: TsoaResponse<500, ErrorJSON>
+    @Res() requestFailedResponse: TsoaResponse<500, ErrorJSON>,
+    @Request() request: ExpressRequest
   ): OpenAPISafeProgram[] | void {
+    const programService = request.app.get('programService')
     this.setStatus(200)
 
-    const programsResult = new ProgramService().getFilteredPrograms(questionnaireData)
+    const programsResult = programService.getFilteredPrograms(questionnaireData)
 
     if (programsResult.isErr) {
       this.throwErrorResponse(programsResult, requestFailedResponse)

--- a/packages/backend/src/program/infrastructure/publicodes.ts
+++ b/packages/backend/src/program/infrastructure/publicodes.ts
@@ -6,6 +6,18 @@ import { ensureError } from '../../common/domain/error/errors'
 import { filterObject } from '../../common/objects'
 import { preprocessInputForPublicodes } from './preprocessProgramsPublicodes'
 
+const initializePublicodesEngine = (rules: object): Result<Engine, Error> => {
+  let engine: Engine
+  try {
+    engine = new Engine(rules)
+  } catch (e) {
+    const err = ensureError(e)
+    return Result.err(err)
+  }
+
+  return Result.ok(engine)
+}
+
 /** Evaluates given program specific rules and user specific input data, if
  * the program should be displayed to the user.
  *
@@ -21,13 +33,12 @@ const evaluateRule = (
 ): Result<boolean | undefined, Error> => {
   const rules = programData.publicodes
 
-  let engine: Engine
-  try {
-    engine = new Engine(rules as object)
-  } catch (e) {
-    const err = ensureError(e)
-    return Result.err(err)
+  const engineResult = initializePublicodesEngine(rules as object)
+  if (engineResult.isErr) {
+    return Result.err(engineResult.error)
   }
+
+  const engine = engineResult.value
 
   const preprocessedData = preprocessInputForPublicodes(questionnaireData, programData, currentDate)
 

--- a/packages/backend/src/program/infrastructure/publicodes.ts
+++ b/packages/backend/src/program/infrastructure/publicodes.ts
@@ -2,7 +2,6 @@ import Engine from 'publicodes'
 import { Result } from 'true-myth'
 import type { Program, QuestionnaireData } from '../domain/types'
 import type { PublicodesInputData } from './types'
-import { ensureError } from '../../common/domain/error/errors'
 import { filterObject } from '../../common/objects'
 import { preprocessInputForPublicodes } from './preprocessProgramsPublicodes'
 
@@ -13,20 +12,14 @@ import { preprocessInputForPublicodes } from './preprocessProgramsPublicodes'
  *   `undefined` if the input data does not allow to fully evaluate the rule) or
  *   the Error if any.
  */
-const evaluateRule = (
+export const evaluateRule = (
   rule: string,
+  engine: Engine,
   programData: Program,
   questionnaireData: QuestionnaireData,
   currentDate: string
 ): Result<boolean | undefined, Error> => {
-  const rules = programData.publicodes
-
-  const engineResult = initializePublicodesEngine(rules as object)
-  if (engineResult.isErr) {
-    return Result.err(engineResult.error)
-  }
-
-  const engine = engineResult.value
+  // const rules = programData.publicodes
 
   const preprocessedData = preprocessInputForPublicodes(questionnaireData, programData, currentDate)
 
@@ -41,22 +34,6 @@ const evaluateRule = (
     return Result.err(new Error(`"${rule}" is expected to be a boolean or undefined`))
   }
   return Result.ok(eligibility)
-}
-
-export const publicodesService = {
-  evaluate: evaluateRule
-}
-
-const initializePublicodesEngine = (rules: object): Result<Engine, Error> => {
-  let engine: Engine
-  try {
-    engine = new Engine(rules)
-  } catch (e) {
-    const err = ensureError(e)
-    return Result.err(err)
-  }
-
-  return Result.ok(engine)
 }
 
 /** Narrows input data to keep only keys expected inside the rules

--- a/packages/backend/src/program/infrastructure/publicodes.ts
+++ b/packages/backend/src/program/infrastructure/publicodes.ts
@@ -19,8 +19,6 @@ export const evaluateRule = (
   questionnaireData: QuestionnaireData,
   currentDate: string
 ): Result<boolean | undefined, Error> => {
-  // const rules = programData.publicodes
-
   const preprocessedData = preprocessInputForPublicodes(questionnaireData, programData, currentDate)
 
   const narrowedData = narrowInput(preprocessedData, engine)

--- a/packages/backend/src/program/infrastructure/publicodes.ts
+++ b/packages/backend/src/program/infrastructure/publicodes.ts
@@ -6,18 +6,6 @@ import { ensureError } from '../../common/domain/error/errors'
 import { filterObject } from '../../common/objects'
 import { preprocessInputForPublicodes } from './preprocessProgramsPublicodes'
 
-const initializePublicodesEngine = (rules: object): Result<Engine, Error> => {
-  let engine: Engine
-  try {
-    engine = new Engine(rules)
-  } catch (e) {
-    const err = ensureError(e)
-    return Result.err(err)
-  }
-
-  return Result.ok(engine)
-}
-
 /** Evaluates given program specific rules and user specific input data, if
  * the program should be displayed to the user.
  *
@@ -57,6 +45,18 @@ const evaluateRule = (
 
 export const publicodesService = {
   evaluate: evaluateRule
+}
+
+const initializePublicodesEngine = (rules: object): Result<Engine, Error> => {
+  let engine: Engine
+  try {
+    engine = new Engine(rules)
+  } catch (e) {
+    const err = ensureError(e)
+    return Result.err(err)
+  }
+
+  return Result.ok(engine)
 }
 
 /** Narrows input data to keep only keys expected inside the rules

--- a/packages/backend/src/program/infrastructure/publicodesService.ts
+++ b/packages/backend/src/program/infrastructure/publicodesService.ts
@@ -5,10 +5,20 @@ import { ensureError } from '../../common/domain/error/errors'
 import { Program, QuestionnaireData } from '../domain/types'
 
 export class PublicodesService {
+  private static instance: PublicodesService
+
   private readonly _publicodeEngines: Record<string, Engine>
 
-  constructor(programs: Program[]) {
+  private constructor(programs: Program[]) {
     this._publicodeEngines = initializePublicodesEngineForAllPrograms(programs)
+  }
+
+  public static init(programs: Program[]): void {
+    PublicodesService.instance = new PublicodesService(programs)
+  }
+
+  public static getInstance(): PublicodesService {
+    return PublicodesService.instance
   }
 
   public evaluate(

--- a/packages/backend/src/program/infrastructure/publicodesService.ts
+++ b/packages/backend/src/program/infrastructure/publicodesService.ts
@@ -8,20 +8,7 @@ export class PublicodesService {
   private readonly _publicodeEngines: Record<string, Engine>
 
   constructor(programs: Program[]) {
-    const engines = programs.reduce(
-      (accu, program) => {
-        const engineResult = initializePublicodesEngine(program.publicodes as object)
-
-        if (engineResult.isErr) {
-          throw engineResult.error
-        }
-        accu[program.id] = engineResult.value
-        return accu
-      },
-      {} as Record<string, Engine>
-    )
-
-    this._publicodeEngines = engines
+    this._publicodeEngines = initializePublicodesEngineForAllPrograms(programs)
   }
 
   public evaluate(
@@ -39,6 +26,21 @@ export class PublicodesService {
     }
     return evaluateRule(rule, engine, program, questionnaireData, currentDate)
   }
+}
+
+const initializePublicodesEngineForAllPrograms = (programs: Program[]): Record<string, Engine> => {
+  return programs.reduce(
+    (accu, program) => {
+      const engineResult = initializePublicodesEngine(program.publicodes as object)
+
+      if (engineResult.isErr) {
+        throw engineResult.error
+      }
+      accu[program.id] = engineResult.value
+      return accu
+    },
+    {} as Record<string, Engine>
+  )
 }
 
 const initializePublicodesEngine = (rules: object): Result<Engine, Error> => {

--- a/packages/backend/src/program/infrastructure/publicodesService.ts
+++ b/packages/backend/src/program/infrastructure/publicodesService.ts
@@ -1,0 +1,54 @@
+import Engine from 'publicodes'
+import { evaluateRule } from './publicodes'
+import { Result } from 'true-myth'
+import { ensureError } from '../../common/domain/error/errors'
+import { Program, QuestionnaireData } from '../domain/types'
+
+export class PublicodesService {
+  private readonly _publicodeEngines: Record<string, Engine>
+
+  constructor(programs: Program[]) {
+    const engines = programs.reduce(
+      (accu, program) => {
+        const engineResult = initializePublicodesEngine(program.publicodes as object)
+
+        if (engineResult.isErr) {
+          throw engineResult.error
+        }
+        accu[program.id] = engineResult.value
+        return accu
+      },
+      {} as Record<string, Engine>
+    )
+
+    this._publicodeEngines = engines
+  }
+
+  public evaluate(
+    rule: string,
+    program: Program,
+    questionnaireData: QuestionnaireData,
+    currentDate: string
+  ): Result<boolean | undefined, Error> {
+    const engine = this._publicodeEngines[program.id]
+    if (!engine) {
+      return Result.err(
+        new Error(`Trying to evaluate a rule on a program for
+      which the publicodes engine has not been initialized : ${program.id}`)
+      )
+    }
+    return evaluateRule(rule, engine, program, questionnaireData, currentDate)
+  }
+}
+
+const initializePublicodesEngine = (rules: object): Result<Engine, Error> => {
+  let engine: Engine
+  try {
+    engine = new Engine(rules)
+  } catch (e) {
+    const err = ensureError(e)
+    return Result.err(err)
+  }
+
+  return Result.ok(engine)
+}

--- a/packages/backend/tests/program/filterPrograms.test.ts
+++ b/packages/backend/tests/program/filterPrograms.test.ts
@@ -1,7 +1,7 @@
 import { type Rules, makeProgramHelper, mockCurrentDateService, makeProgramsRepository } from './testing'
 import { FILTERING_RULE_NAME } from '../../src/program/domain/filterPrograms'
 import type { Program, QuestionnaireData } from '../../src/program/domain/types'
-import { expectToBeErr, expectToBeOk } from '../testing'
+import { expectToBeOk } from '../testing'
 import ProgramFeatures from '../../src/program/domain/programFeatures'
 import { type Result } from 'true-myth'
 import { PublicodesService } from '../../src/program/infrastructure/publicodesService'
@@ -17,7 +17,12 @@ const rulesBoilerplate = {
   [FILTERING_RULE_NAME]: 'entreprise . effectif > 0'
 }
 
-const makeProgram = (rules: Rules) => makeProgramHelper({ rules: rules })
+let id: number = 0
+
+const makeProgram = (rules: Rules) => {
+  id = id + 1
+  return makeProgramHelper({ id: 'id' + id.toString(), rules: rules })
+}
 
 // Helper function that performs type narrowing.
 // Not automatic in jest, see https://github.com/jestjs/jest/issues/10094
@@ -175,11 +180,9 @@ error`, () => {
 describe(`
   GIVEN  a rule
   WHEN   the rule is not valid Publicodes
-  EXPECT an explicit error
+  EXPECT the creation of ProgramFeature to fail with a thrown error
 `, () => {
   test('invalid rule', () => {
-    const result = defaultFilterPrograms([makeProgram({ [FILTERING_RULE_NAME]: 'invalid Publicode expression' })], {})
-
-    expectToBeErr(result)
+    expect(() => defaultFilterPrograms([makeProgram({ [FILTERING_RULE_NAME]: 'invalid Publicode expression' })], {})).toThrow()
   })
 })

--- a/packages/backend/tests/program/filterPrograms.test.ts
+++ b/packages/backend/tests/program/filterPrograms.test.ts
@@ -7,7 +7,8 @@ import { type Result } from 'true-myth'
 import { PublicodesService } from '../../src/program/infrastructure/publicodesService'
 
 const defaultFilterPrograms = (programs: Program[], inputData: QuestionnaireData): Result<Program[], Error> => {
-  const programService = new ProgramFeatures(makeProgramsRepository(programs), mockCurrentDateService, new PublicodesService(programs))
+  PublicodesService.init(programs)
+  const programService = new ProgramFeatures(makeProgramsRepository(programs), mockCurrentDateService, PublicodesService.getInstance())
   return programService.getFilteredBy(inputData)
 }
 

--- a/packages/backend/tests/program/filterPrograms.test.ts
+++ b/packages/backend/tests/program/filterPrograms.test.ts
@@ -4,10 +4,10 @@ import type { Program, QuestionnaireData } from '../../src/program/domain/types'
 import { expectToBeErr, expectToBeOk } from '../testing'
 import ProgramFeatures from '../../src/program/domain/programFeatures'
 import { type Result } from 'true-myth'
-import { publicodesService } from '../../src/program/infrastructure/publicodes'
+import { PublicodesService } from '../../src/program/infrastructure/publicodesService'
 
 const defaultFilterPrograms = (programs: Program[], inputData: QuestionnaireData): Result<Program[], Error> => {
-  const programService = new ProgramFeatures(makeProgramsRepository(programs), mockCurrentDateService, publicodesService)
+  const programService = new ProgramFeatures(makeProgramsRepository(programs), mockCurrentDateService, new PublicodesService(programs))
   return programService.getFilteredBy(inputData)
 }
 

--- a/packages/backend/tests/program/preprocessPrograms.test.ts
+++ b/packages/backend/tests/program/preprocessPrograms.test.ts
@@ -7,7 +7,7 @@ import { makeProgramHelper, mockCurrentDateService, makeProgramsRepository } fro
 import { FILTERING_RULE_NAME } from '../../src/program/domain/filterPrograms'
 import { expectToBeOk } from '../testing'
 import ProgramFeatures from '../../src/program/domain/programFeatures'
-import { publicodesService } from '../../src/program/infrastructure/publicodes'
+import { PublicodesService } from '../../src/program/infrastructure/publicodesService'
 
 const makeProgram = (rules: object) => makeProgramHelper({ rules: { ...{ [FILTERING_RULE_NAME]: { valeur: 'oui' } }, ...rules } })
 
@@ -85,9 +85,12 @@ const testHelperPreprocessing = (testCase: PreprocessingTestCase) => {
       testCurrentDateService = { get: () => testCase.currentDate }
     }
 
-    const result = new ProgramFeatures(makeProgramsRepository([program]), testCurrentDateService, publicodesService).getFilteredBy(
-      questionnaireData
-    )
+    const programs = [program]
+    const result = new ProgramFeatures(
+      makeProgramsRepository(programs),
+      testCurrentDateService,
+      new PublicodesService(programs)
+    ).getFilteredBy(questionnaireData)
 
     expectToBeOk(result)
 

--- a/packages/backend/tests/program/preprocessPrograms.test.ts
+++ b/packages/backend/tests/program/preprocessPrograms.test.ts
@@ -86,10 +86,11 @@ const testHelperPreprocessing = (testCase: PreprocessingTestCase) => {
     }
 
     const programs = [program]
+    PublicodesService.init(programs)
     const result = new ProgramFeatures(
       makeProgramsRepository(programs),
       testCurrentDateService,
-      new PublicodesService(programs)
+      PublicodesService.getInstance()
     ).getFilteredBy(questionnaireData)
 
     expectToBeOk(result)


### PR DESCRIPTION
Fix #164

# Context 

PR #371 introduit le filtrage côté backend. 

# Refactorings. 

Cette PR profite de ce changement pour résoudre #164 en initialisant les règles publicodes de tous les dispositifs au lancement du serveur, plutôt qu'à chaque appel d'API. 

Gain de performance observé en local : on passe de + de 2.5s à moins de 1s. Les tests effectués sur le serveur de preprod donnent les mêmes résultats. 

# Tests

Des tests ont été cassé par les changements introduits : 

- l'initialisation de publicodes suppose des identifiants de programme uniques (on fait un mapping "identifiant" > "moteur publicodes"), ce qui n'était pas le cas dans certains tests jusqu'à présent. 
- On testé que le filtrage échouait en cas d'instruction publicodes invalide. L'erreur est maintenant remontée dès l'instanciation du service (donc en pratique dès le lancement du serveur).

