### PR TITLE
chore: migrate old contacts into opportunities [ci skip]

### DIFF
--- a/packages/data/tools/brevo_migration/brevo_migration.js
+++ b/packages/data/tools/brevo_migration/brevo_migration.js
@@ -25,7 +25,7 @@ const requestAllBrevoContacts = async () => {
 
   apiInstance.setApiKey(SibApiV3Sdk.AccountApiApiKeys.apiKey, token)
 
-  const limit = 50
+  const limit = 150
   const offset = 155
   const listIds = 2
 
@@ -117,10 +117,31 @@ const updateProgramId = (id) => {
   switch (id) {
     case 'formations-actions-baisse-les-watts':
       return 'baisse-les-watts'
+
     case 'etude-photovoltaique':
+      return 'etude-photovoltaique-cci'
+    case 'etude-photovoltaique-2':
       return 'etude-photovoltaique-ademe'
+
+    case 'visite-energie':
+      return 'visite-energie-cci'
+    case 'visite-energie-2':
+      return 'visite-energie-cma'
+
     case 'formations-rse':
       return 'formations-tee'
+    case 'audits-cle-verte':
+      return 'audits-clef-verte'
+
+    case 'etudes-ademe-photovoltaique':
+      return 'investissement-solaire-thermique'
+
+    case 'diag-ecoconception-2':
+      return 'diag-ecoconception'
+
+    case 'diag-decarbon-action-2':
+      return 'diag-decarbon-action'
+
     default:
       return id
   }

--- a/packages/data/tools/brevo_migration/brevo_migration.js
+++ b/packages/data/tools/brevo_migration/brevo_migration.js
@@ -25,13 +25,13 @@ const requestAllBrevoContacts = async () => {
 
   apiInstance.setApiKey(SibApiV3Sdk.AccountApiApiKeys.apiKey, token)
 
-  const limit = 150
-  const offset = 155
-  const listIds = 2
+  const limit = 500
+  const offset = 500
+  const listId = 2
 
   let contacts
 
-  contacts = await apiInstance.getContacts(limit, offset, undefined, undefined, undefined, { listIds: listIds }).then(
+  contacts = await apiInstance.getContactsFromList(listId, undefined, limit, offset).then(
     function (data) {
       return data.body.contacts
     },
@@ -136,11 +136,24 @@ const updateProgramId = (id) => {
     case 'etudes-ademe-photovoltaique':
       return 'investissement-solaire-thermique'
 
+    case 'conseillers-renovation-petit-tertiaire-prive':
+      return 'renovation-petit-tertiaire-prive'
+
+    case 'etude-de-faisabilite-d-installation-solaire-thermique':
+      return 'etude-solaire-thermique'
+
+    case 'diag-ecoflux':
+      return 'diag-eco-flux'
+
+    case 'tpe-gagnantes':
+      return 'tpe-gagnantes-sur-tous-les-couts'
+
     case 'diag-ecoconception-2':
       return 'diag-ecoconception'
-
     case 'diag-decarbon-action-2':
       return 'diag-decarbon-action'
+    case 'diag-eco-flux-2':
+      return 'diag-eco-flux'
 
     default:
       return id

--- a/packages/data/tools/brevo_migration/brevo_migration.js
+++ b/packages/data/tools/brevo_migration/brevo_migration.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+// Script to migrate opportunity data originally stored as contact information into Brevo Deals
+// Needs brevo token exported as environment variable BREVO_API_TOKEN to run
+
+const SibApiV3Sdk = require('@getbrevo/brevo')
+const ProgramApplication = require('@tee/backend/build/backend/src/program/application/programService')
+
+const testPipeline = {
+  pipeline: '65ce1a5e59d96ff2630f06c8',
+  deal_stage: 'C8DrOEJbVoiqtWZHQbMHyxF'
+}
+
+// const prod_pipeline = {
+//   pipeline: '65719d9023acb4f05e56e7eb',
+//   deal_stage: '659d15cff01695.94588187'
+// }
+
+let selectedPipeline = testPipeline
+
+const requestAllBrevoContacts = async () => {
+  let apiInstance = new SibApiV3Sdk.ContactsApi()
+
+  const token = process.env['BREVO_API_TOKEN'] || ''
+
+  apiInstance.setApiKey(SibApiV3Sdk.AccountApiApiKeys.apiKey, token)
+
+  const limit = 50
+  const offset = 155
+  const listIds = 2
+
+  let contacts
+
+  contacts = await apiInstance.getContacts(limit, offset, undefined, undefined, undefined, { listIds: listIds }).then(
+    function (data) {
+      return data.body.contacts
+    },
+    function (error) {
+      console.error(error)
+    }
+  )
+
+  return contacts
+}
+
+const filterOldContacts = (contacts) => {
+  return contacts.filter((c) => {
+    return 'PROGRAM_ID' in c.attributes
+  })
+}
+
+const translateContactsToOpportunities = (contacts) => {
+  const ProgramService = ProgramApplication.default
+  ProgramService.init()
+  const service = new ProgramService()
+
+  return contacts.map((contact) => translateOneContactToOpportunity(contact, service))
+}
+
+const translateOneContactToOpportunity = (contact, service) => {
+  let allResponses
+  if (contact.attributes.ALL_RESPONSES) {
+    allResponses = parseAllResponses(contact.attributes.ALL_RESPONSES)
+  }
+
+  // Some programs id have changed in the meanwhile
+  const updatedId = updateProgramId(contact.attributes.PROGRAM_ID)
+  const program = service.getById(updatedId)
+
+  console.log(program ? program['opérateur de contact'] : undefined)
+
+  const opportunity = {
+    name: updatedId,
+    attributes: {
+      pipeline: selectedPipeline.pipeline,
+      deal_stage: selectedPipeline.deal_stage,
+      created_at: contact.createdAt,
+      last_updated_date: contact.modifiedAt,
+      message: contact.attributes.FORM_NEEDS,
+      oprateur_de_contact: program ? program['opérateur de contact'] : undefined,
+      parcours: allResponses ? allResponses.user_help : 'annuaire',
+      autres_donnes: contact.attributes.ALL_RESPONSES
+    },
+    contact_id: contact.id
+  }
+  return opportunity
+}
+
+const parseAllResponses = (txt) => {
+  const splitted = txt.split(' / ')
+  const parsed = {}
+  for (const s of splitted) {
+    keyValue = s.split(': ')
+
+    key = keyValue[0]
+    value = keyValue[1]
+
+    if (key == 'user_help') {
+      value = translateUserHelp(value)
+    }
+
+    parsed[key] = value
+  }
+  return parsed
+}
+
+const translateUserHelp = (value) => {
+  if (value == 'precise') {
+    value = 'jai_un_objectif_prcis'
+  } else {
+    value = 'je_ne_sais_pas_par_o_commencer'
+  }
+  return value
+}
+
+const updateProgramId = (id) => {
+  switch (id) {
+    case 'formations-actions-baisse-les-watts':
+      return 'baisse-les-watts'
+    case 'etude-photovoltaique':
+      return 'etude-photovoltaique-ademe'
+    case 'formations-rse':
+      return 'formations-tee'
+    default:
+      return id
+  }
+}
+
+const sendOpportunitiesToBrevo = async (opportunities) => {
+  let apiInstance = new SibApiV3Sdk.DealsApi()
+
+  const token = process.env['BREVO_API_TOKEN'] || ''
+
+  apiInstance.setApiKey(SibApiV3Sdk.AccountApiApiKeys.apiKey, token)
+
+  for (let opportunity of opportunities) {
+    const opportunity_id = await apiInstance.crmDealsPost(opportunity).then(
+      function (data) {
+        return data.body.id
+      },
+      function (error) {
+        console.error(`Import failed with opportunity ${JSON.stringify(opportunity, null, 2)}: ${error}`)
+      }
+    )
+
+    apiInstance.crmDealsLinkUnlinkIdPatch(opportunity_id, { linkContactIds: [opportunity.contact_id] }).catch(function (error) {
+      console.error(`Could not link opportunity with ${opportunity.contact_id}: ${error}`)
+    })
+  }
+}
+
+const migrateOldContacts = async () => {
+  const contacts = await requestAllBrevoContacts()
+  const oldContacts = filterOldContacts(contacts)
+  const opportunities = translateContactsToOpportunities(oldContacts)
+  await sendOpportunitiesToBrevo(opportunities)
+}
+
+migrateOldContacts()

--- a/packages/data/tools/brevo_migration/brevo_migration.js
+++ b/packages/data/tools/brevo_migration/brevo_migration.js
@@ -11,10 +11,10 @@ const testPipeline = {
   deal_stage: 'C8DrOEJbVoiqtWZHQbMHyxF'
 }
 
-// const prod_pipeline = {
-//   pipeline: '65719d9023acb4f05e56e7eb',
-//   deal_stage: '659d15cff01695.94588187'
-// }
+const prodPipeline = {
+  pipeline: '65719d9023acb4f05e56e7eb',
+  deal_stage: '659d15cff01695.94588187'
+}
 
 let selectedPipeline = testPipeline
 


### PR DESCRIPTION
Contexte :  #549 

N'a pas vocation à être mergée, mais je la mets là pour éventuellement référence ultérieure.

# Lancer le script en production

1. Exporter la variable d'environnement BREVO_API_TOKEN. Par exemple directement à partir du .env : 

```
cd packages/backend
set -o allexport && source .env && set +o allexport
```

2. Modifier le script pour qu'il dirige les opportunités vers la pipeline de prod. Le script se trouve dans packages/data/tools/brevo_migration :

Ligne 19: remplacer `testPipeline` par `prodPipeline`

3. lancer le script, qui est exécutable : `./brevo_migration.js`a

4. ...

5. Profit (sinon, m'appeler à la rescousse). 

# Détails

- Le script n'appelle pas notre API backend pour les imports, donc pas de risque de spammer Bpifrance.
- J'ai fait exprès d'interrompre la CI pour ne pas lancer une machine scalingo pour rien. 

