### PR TITLE
hotfix: clean values to null sent to the backend "api/programs" entry point

### DIFF
--- a/packages/web/src/service/api/programApi.ts
+++ b/packages/web/src/service/api/programApi.ts
@@ -35,8 +35,8 @@ export default class ProgramApi extends RequestApi {
 
   get query(): string {
     const queryString: { [key: string]: string } = {}
-    Object.entries(this.questionnaireData).forEach(([key, value]: [string, string | string[] | undefined]) => {
-      if (value !== undefined) {
+    Object.entries(this.questionnaireData).forEach(([key, value]: [string, string | string[] | undefined | null]) => {
+      if (value !== undefined && value !== null) {
         queryString[key] = value.toString()
       }
     })


### PR DESCRIPTION
Le filtre sur les valeurs envoyé au point d'entré d'api "api/programs" ne peuvent pas être égale à null car la method js `.toString` est utilisé et donc renvoie une fatale erreur 